### PR TITLE
Implement RFC 9457 Error Handling, Typechecking performance improvement and neutral OpenTelemetry tracing.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,11 @@ module.exports = {
 	rules: {
 		'quotes': ['warn', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
 		'@stylistic/semi': ['warn', 'never'],
+		'@stylistic/member-delimiter-style': ['warn', {
+			multiline: { delimiter: 'none' },
+			singleline: { delimiter: 'comma', requireLast: false },
+		}],
+		'no-mixed-spaces-and-tabs': 'warn',
 		'padded-blocks': 'off',
 		'no-trailing-spaces': ['warn', { skipBlankLines: true }],
 		'no-tabs': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
 	parserOptions: {
 		ecmaVersion: 'latest', sourceType: 'module', project: ['./tsconfig.json']
 	},
-	ignorePatterns: ['.eslintrc.cjs', '**/*.tst.ts', 'dist'],
+	ignorePatterns: ['.eslintrc.cjs', '**/*.tst.ts', 'dist', 'bench'],
 	plugins: ['@typescript-eslint', '@stylistic'],
 	rules: {
 		'quotes': ['warn', 'single', { avoidEscape: true, allowTemplateLiterals: true }],

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,10 +3,10 @@ name: On Pull Requests to Main
 on:
   pull_request:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - 'package.json'
-      - 'src/**'
+      - "package.json"
+      - "src/**"
 
 jobs:
   verify-semver:
@@ -14,49 +14,49 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
-    steps:
-    - name: Checkout PR branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
-      with:
-        bun-version: latest
-        
-    - name: Install production dependencies
-      run: bun install --production
-      
-    - name: Dry Run Publish
-      run: bun publish --dry-run --registry https://npm.pkg.github.com
-      env:
-        NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Get PR package version
-      id: pr_version
-      run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-    
-    - name: Checkout main branch
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.base_ref }}
-    
-    - name: Get main package version
-      id: main_version
-      run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
-    
-    - name: Compare semantic versions
-      id: semver
-      uses: aleoyakas/check-semver-increased-action@v1
-      with:
-        current-version: ${{ steps.pr_version.outputs.version }}
-        previous-version: ${{ steps.main_version.outputs.version }}
-        allow-pre-release: true
-    
-    - name: Fail if version not bumped
-      if: steps.semver.outputs.is-version-increased != 'true'
-      run: |
-        echo "::error::The version in package.json must be bumped above the main branch version."
-        exit 1
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.14
+
+      - name: Install production dependencies
+        run: bun install --production
+
+      - name: Dry Run Publish
+        run: bun publish --dry-run --registry https://npm.pkg.github.com
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR package version
+        id: pr_version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Get main package version
+        id: main_version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Compare semantic versions
+        id: semver
+        uses: aleoyakas/check-semver-increased-action@v1
+        with:
+          current-version: ${{ steps.pr_version.outputs.version }}
+          previous-version: ${{ steps.main_version.outputs.version }}
+          allow-pre-release: true
+
+      - name: Fail if version not bumped
+        if: steps.semver.outputs.is-version-increased != 'true'
+        run: |
+          echo "::error::The version in package.json must be bumped above the main branch version."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist
 
 # generated files
 **/generated.ts
+bench/consumer.ts
+bench/trace
 
 # code coverage
 coverage

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
 - [Errors](#errors)
   - [Declaring errors](#declaring-errors)
   - [Throwing errors](#throwing-errors)
-  - [The `problems()` plugin](#the-problems-plugin)
+  - [The `procedures()` plugin](#the-procedures-plugin)
   - [Wire contract](#wire-contract)
   - [OpenAPI](#openapi)
 - [Telemetry](#telemetry)
@@ -274,7 +274,7 @@ const baseProcedure = createProcedure("Basic Procedure")
 
 ## Errors
 
-Errors are a first-class part of a procedure chain. You declare an **error table** once, throw errors through the typed `onError` factory injected into every handler, and let the `problems()` plugin turn everything that escapes a route into an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) `application/problem+json` response.
+Errors are a first-class part of a procedure chain. You declare an **error table** once, throw errors through the typed `onError` factory injected into every handler, and let the `procedures()` plugin turn everything that escapes a route into an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) `application/problem+json` response.
 
 The package has no opinion on reason names, status mapping or metadata shape; it only provides the mechanics.
 
@@ -349,45 +349,73 @@ const getVideo = baseProcedure
 
 `onError(reason, metadata?, options?)` returns an `ApiError` with public `status`, `reason`, `metadata`, `title`, `detail`, `type` and `cause`; you throw it. Copy is resolved as `options` → entry function or string → fallback (`title` is the reason in Title Case, no `detail`). Passing metadata that does not match the schema throws a plain `TypeError`, since that is a programming error rather than an API error.
 
-### The `problems()` plugin
+### The `procedures()` plugin
 
-Mount the plugin **once, on the root app, before any sub-apps**. It registers the `Problem` and `ValidationProblem` models that `action.docs` reference and a global `onError` hook that serializes every failure. Elysia applies global hooks to every route registered after them, at any nesting depth, so sub-apps need nothing; a sub-app `.use()`d *before* the plugin is not covered.
+`procedures()` is the library's Elysia integration. Mount it **once, on the root app, before any sub-apps**. It registers the `Problem` and `ValidationProblem` models that `action.docs` reference and a global `onError` hook that serializes every failure. Elysia applies global hooks to every route registered after them, at any nesting depth, so sub-apps need nothing; a sub-app `.use()`d *before* the plugin is not covered.
 
 ```typescript
 import { Elysia } from "elysia";
-import { problems } from "@luukgoossen/elysia-procedures";
+import { procedures, sentryReporter } from "@luukgoossen/elysia-procedures";
 
 const app = new Elysia()
   .use(
-    problems({
-      // report 4xx ApiErrors to Sentry as messages: "off" (default) | "warn" | "all"
-      captureClientErrors: "off",
-      // same shape as the procedure config; used for the problems the plugin builds itself
-      errors: { type: (reason) => `https://example.com/docs/errors/${reason}` },
-      // max characters of a field's `received` value echoed back; default 200
-      receivedMaxLength: 200,
-      // override logging; default console.warn for 4xx and console.error for 5xx
-      log: (level, fields) => logger[level](fields),
+    procedures({
+      // the wire contract: same shape as the procedure config, used for the problems the plugin builds itself
+      errors: {
+        type: (reason) => `https://example.com/docs/errors/${reason}`,
+        // max characters of a field's `received` value echoed back; default 200
+        receivedMaxLength: 200,
+      },
+      // policy: how handled failures are reported and logged
+      observability: {
+        // reports failures and yields the `reference`; default: sentryReporter()
+        errorReporting: sentryReporter({ captureClientErrors: "warn" }),
+        // default console.warn for 4xx and console.error for 5xx
+        logging: (level, fields) => logger[level](fields),
+      },
     }),
   )
   .get("/videos/:id", getVideo.handle, getVideo.docs)
   .listen(3000);
 ```
 
-| thrown                                         | status     | Sentry                                             | body                                           |
-| ---------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------- |
-| `ApiError` < 500                               | its status | none unless `captureClientErrors` is on            | the error's problem                            |
-| `ApiError` >= 500                              | its status | `captureException` (the `cause` chain is reported) | the error's problem with a `reference`         |
-| Elysia validation error                        | 422        | none                                               | `INVALID_INPUT` with per-field `errors`        |
-| Elysia parse error or invalid cookie signature | 400        | none                                               | `MALFORMED_REQUEST`                            |
-| Elysia invalid file type                       | 422        | none                                               | `INVALID_INPUT` with one field error           |
-| unknown route                                  | 404        | none                                               | `NOT_FOUND`                                    |
-| redirects, thrown `Response`s, `status(...)`   | as is      | none                                               | untouched                                      |
-| anything else                                  | 500        | `captureException`                                 | `INTERNAL` with default copy and a `reference` |
+| thrown                                                        | status     | body                                    |
+| ------------------------------------------------------------- | ---------- | --------------------------------------- |
+| `ApiError`                                                    | its status | the error's problem                     |
+| Elysia validation error                                       | 422        | `INVALID_INPUT` with per-field `errors` |
+| Elysia parse error or invalid cookie signature                | 400        | `MALFORMED_REQUEST`                     |
+| Elysia invalid file type                                      | 422        | `INVALID_INPUT` with one field error    |
+| unknown route                                                 | 404        | `NOT_FOUND`                             |
+| redirects, thrown `Response`s, `status(...)`                  | as is      | untouched                               |
+| anything else, including a response failing the output schema | 500        | `INTERNAL` with default copy            |
 
-Sentry is loaded through a dynamic import of `@sentry/bun` and skipped when it is not installed. Every branch logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log.
+Reporting is a separate policy. The default `sentryReporter()` captures every 5xx problem as an exception (Sentry follows the `cause` chain) and, with `captureClientErrors`, 4xx `ApiError`s as messages; it loads `@sentry/bun` through a dynamic import and does nothing when it is not installed. Whatever the reporter returns becomes the problem's `reference`. Every handled failure logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log, and only for 5xx.
 
 Without the plugin nothing fails loudly, but you lose the contract: a thrown `ApiError` becomes a plain-text response with the right status, an unexpected `Error` is answered with its raw message (Elysia's default), validation failures use Elysia's own JSON shape, and the OpenAPI spec references `Problem` schemas that are never emitted. The `.get(path, action.handle, action.docs)` pattern above assumes the plugin is mounted.
+
+#### Bringing your own handler
+
+`procedures()` is a composition of exported pieces, so an app with its own `onError` (HTML error pages, another error tracker, a different logging stack) can keep the wire contract without the policy:
+
+- `procedureModels()` registers the `Problem` and `ValidationProblem` models that `action.docs` reference and `ApiError` as a known error. Mount it instead of `procedures()`.
+- `resolveProblem(code, error, { instance?, errors?, receivedMaxLength? })` is the behaviour table above as a pure function: no reporting, no logging, never a raw message, and `undefined` for values that should pass through.
+- `problemResponse(problem)` serializes to `application/problem+json`.
+- `sentryReporter(options)` is the default reporter, reusable on its own.
+
+```typescript
+import { Elysia } from "elysia";
+import { procedureModels, resolveProblem, problemResponse } from "@luukgoossen/elysia-procedures";
+
+const app = new Elysia()
+  .use(procedureModels())
+  .onError(async ({ code, error, request }) => {
+    const problem = resolveProblem(code, error, { instance: new URL(request.url).pathname });
+    if (!problem) return; // redirect or early return, let Elysia handle it
+
+    const reference = problem.status >= 500 ? await myTracker.capture(error) : undefined;
+    return problemResponse({ ...problem, reference });
+  });
+```
 
 ### Wire contract
 
@@ -437,19 +465,17 @@ This package supports telemetry tracing. Both `@sentry/bun` and `@elysiajs/opent
 
 The builder chain is designed to keep the type checker's work per action small: schema constraints are checked structurally instead of against `TObject` (which would evaluate every schema's static type twice), schemas are only re-wrapped when there is something to merge, and `onError` is a single generic signature resolved per call instead of one overload per table entry. With ~250 actions the library itself accounts for well under half a million type instantiations.
 
-The dominant cost in a large server is Elysia's own route typing, which grows faster than linearly with the number of routes registered on **one** instance. When `tsc`, ESLint or the editor become slow, split the registrations into sub-apps and mount them on the main app. Each sub-app needs `problems()` as well so the `Problem` response models resolve; the plugin is named, so Elysia deduplicates it and every error is still handled exactly once:
+The dominant cost in a large server is Elysia's own route typing, which grows faster than linearly with the number of routes registered on **one** instance. When `tsc`, ESLint or the editor become slow, split the registrations into sub-apps and mount them on the main app. The sub-apps need nothing extra: `procedures()` on the root covers them at runtime, and `action.docs` typechecks on any instance.
 
 ```typescript
 const products = new Elysia({ prefix: "/products" })
-  .use(problems())
   .get("/:productId", getProductAction.handle, getProductAction.docs)
   .post("/:productId/update", updateProductAction.handle, updateProductAction.docs);
 
 const orders = new Elysia({ prefix: "/orders" })
-  .use(problems())
   .get("/", listOrdersAction.handle, listOrdersAction.docs);
 
-const app = new Elysia().use(problems()).use(products).use(orders).listen(3000);
+const app = new Elysia().use(procedures()).use(products).use(orders).listen(3000);
 ```
 
 In a benchmark with 500 actions registered with `.handle` and `.docs`, moving from one chain to sub-apps of 25 routes cut the checker from 6.6M to 3.6M type instantiations and peak memory from 1.1GB to 0.8GB. Splitting the sub-apps over several files additionally lets the editor re-check only the file being edited.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
   - [Creating Actions](#creating-actions)
 - [Integrating with Elysia](#integrating-with-elysia)
 - [Caching](#caching)
+- [Errors](#errors)
+  - [Declaring errors](#declaring-errors)
+  - [Throwing errors](#throwing-errors)
+  - [The `problems()` plugin](#the-problems-plugin)
+  - [Wire contract](#wire-contract)
+  - [OpenAPI](#openapi)
 - [Telemetry](#telemetry)
 - [Acknowledgments](#acknowledgments)
 
@@ -24,6 +30,7 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
 - 🧩 **Composable** - Create reusable procedures and middleware
 - 📚 **Documentation** - Co-locate your OpenAPI documentation with the handlers
 - 💾 **Caching** - Dependency-based request-level caching
+- 🚨 **Errors** - Typed error tables, RFC 9457 `application/problem+json` responses and a safe Sentry policy
 - 🔗 **tRPC-style** - Familiar procedure-based patterns for type-safe APIs
 
 ## Installation
@@ -72,12 +79,12 @@ const userProcedure = createProcedure("With User Profile", authProcedure)
   .params(
     Type.Object({
       userId: Type.String(),
-    })
+    }),
   )
   .query(
     Type.Object({
       include: Type.Optional(Type.String()),
-    })
+    }),
   )
   .build(({ ctx, params, query }) => {
     // ctx.user is available because of the auth middleware
@@ -97,7 +104,7 @@ const getUserAction = userProcedure
       name: Type.String(),
       email: Type.String(),
       role: Type.String(),
-    })
+    }),
   )
   .build(({ ctx, params }) => {
     // Fetch user data based on params.userId
@@ -139,23 +146,23 @@ const productProcedure = createProcedure("Ensure Product", baseProcedure)
   .params(
     Type.Object({
       productId: Type.String(),
-    })
+    }),
   )
   .query(
     Type.Object({
       currency: Type.Optional(Type.String({ default: "USD" })),
       format: Type.Optional(Type.Enum({ json: "json", xml: "xml" })),
-    })
+    }),
   )
   .body(
     Type.Object({
       includeDetails: Type.Boolean(),
-    })
+    }),
   )
   .build(({ params, query, body, ctx }) => {
     // All inputs are validated and typed
     console.log(
-      `Fetching product ${params.productId} in ${query.currency} format`
+      `Fetching product ${params.productId} in ${query.currency} format`,
     );
 
     return {
@@ -180,9 +187,9 @@ const getProductAction = productProcedure
         Type.Object({
           description: Type.String(),
           specifications: Type.Array(Type.String()),
-        })
+        }),
       ),
-    })
+    }),
   )
   .build(({ params, query, body, ctx }) => {
     // Fetch product from database
@@ -214,7 +221,7 @@ const app = new Elysia()
   .post(
     "/products/:productId/update",
     updateProductAction.handle,
-    updateProductAction.docs
+    updateProductAction.docs,
   )
   .listen(3000);
 ```
@@ -251,7 +258,7 @@ const baseProcedure = createProcedure("Basic Procedure")
   .params(
     Type.Object({
       productId: Type.String(),
-    })
+    }),
   )
   .cache(({ params }) => [params.productId])
   .build(async ({ ctx }) => {
@@ -263,6 +270,161 @@ const baseProcedure = createProcedure("Basic Procedure")
     return { requestTime: new Date() };
   });
 ```
+
+## Errors
+
+Errors are a first-class part of a procedure chain. You declare an **error table** once, throw errors through the typed `onError` factory injected into every handler, and let the `problems()` plugin turn everything that escapes a route into an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) `application/problem+json` response.
+
+The package has no opinion on reason names, status mapping or metadata shape; it only provides the mechanics.
+
+### Declaring errors
+
+Errors live in the `config` of `createProcedure` (and in the `details` of `createAction`). Tables are merged **by key** down the chain: the child wins, and the `type` function is inherited when the child does not set one.
+
+```typescript
+import { createProcedure } from "@luukgoossen/elysia-procedures";
+import { Type } from "@sinclair/typebox";
+
+const baseProcedure = createProcedure("Base", undefined, {
+  errors: {
+    // builds the RFC 9457 `type` URI for a reason; defaults to "about:blank"
+    type: (reason) => `https://example.com/docs/errors/${reason}`,
+    table: {
+      NOT_FOUND: {
+        status: 404,
+        metadata: Type.Object({ entity: Type.String(), id: Type.String() }),
+        title: (m: { entity: string; id: string }) => `${m.entity} not found`,
+        detail:
+          "The resource you requested does not exist or has been removed.",
+      },
+      FORBIDDEN: { status: 403, title: "You are not allowed to do that" },
+      UPSTREAM_DOWN: { status: 502, title: "Upstream unavailable" },
+    },
+  },
+}).build();
+
+// child procedures and actions add or override entries
+const adminProcedure = createProcedure("Admin", baseProcedure, {
+  errors: { table: { FORBIDDEN: { status: 403, title: "Admins only" } } },
+}).build();
+```
+
+Each entry has a `status`, an optional TypeBox `metadata` schema (required when calling `onError` if present), and an optional `title` / `detail` that is either a string or a function of the validated metadata. Inside a plain object literal the metadata parameter of those functions must be annotated; wrap the entry in `defineError(...)` to have it inferred from the schema:
+
+```typescript
+import { defineError } from "@luukgoossen/elysia-procedures";
+
+NOT_FOUND: defineError({
+  status: 404,
+  metadata: Type.Object({ entity: Type.String() }),
+  title: (m) => `${m.entity} not found`, // m is { entity: string }
+}),
+```
+
+Four entries are always present, callable from every handler, and can be overridden by key but not removed: `INTERNAL` (500), `INVALID_INPUT` (422), `MALFORMED_REQUEST` (400) and `NOT_FOUND` (404). The plugin uses them for failures that are not `ApiError`s.
+
+Keep `status` values literal (inline object literals or `defineError`) so the documented response statuses stay typed; a table stored in a variable without `as const` widens them to `number`.
+
+### Throwing errors
+
+Every handler and middleware receives `onError` as its **second argument**. It is typed from the effective table: unknown reasons do not compile, and metadata is required exactly when the entry declares a schema.
+
+```typescript
+const getVideo = baseProcedure
+  .createAction("Get Video")
+  .params(Type.Object({ id: Type.String() }))
+  .build(async ({ params }, onError) => {
+    const video = await db.videos.find(params.id);
+    if (!video) throw onError("NOT_FOUND", { entity: "Video", id: params.id });
+
+    try {
+      return await enrich(video);
+    } catch (cause) {
+      // wraps an unexpected failure as a 500 (or another >= 500 reason) without leaking it
+      throw onError.unexpected(cause, { reason: "UPSTREAM_DOWN" });
+    }
+  });
+```
+
+`onError(reason, metadata?, options?)` returns an `ApiError` with public `status`, `reason`, `metadata`, `title`, `detail`, `type` and `cause`; you throw it. Copy is resolved as `options` → entry function or string → fallback (`title` is the reason in Title Case, no `detail`). Passing metadata that does not match the schema throws a plain `TypeError`, since that is a programming error rather than an API error.
+
+### The `problems()` plugin
+
+Mount the plugin on your Elysia app. It registers the `Problem` model (which `action.docs` references) and an `onError` hook that serializes every failure. It is idempotent, so use it on every instance that mounts actions.
+
+```typescript
+import { Elysia } from "elysia";
+import { problems } from "@luukgoossen/elysia-procedures";
+
+const app = new Elysia()
+  .use(
+    problems({
+      // report 4xx ApiErrors to Sentry as messages: "off" (default) | "warn" | "all"
+      captureClientErrors: "off",
+      // same shape as the procedure config; used for the problems the plugin builds itself
+      errors: { type: (reason) => `https://example.com/docs/errors/${reason}` },
+      // max characters of a field's `received` value echoed back; default 200
+      receivedMaxLength: 200,
+      // override logging; default console.warn for 4xx and console.error for 5xx
+      log: (level, fields) => logger[level](fields),
+    }),
+  )
+  .get("/videos/:id", getVideo.handle, getVideo.docs)
+  .listen(3000);
+```
+
+| thrown                                         | status     | Sentry                                             | body                                           |
+| ---------------------------------------------- | ---------- | -------------------------------------------------- | ---------------------------------------------- |
+| `ApiError` < 500                               | its status | none unless `captureClientErrors` is on            | the error's problem                            |
+| `ApiError` >= 500                              | its status | `captureException` (the `cause` chain is reported) | the error's problem with a `reference`         |
+| Elysia validation error                        | 422        | none                                               | `INVALID_INPUT` with per-field `errors`        |
+| Elysia parse error or invalid cookie signature | 400        | none                                               | `MALFORMED_REQUEST`                            |
+| Elysia invalid file type                       | 422        | none                                               | `INVALID_INPUT` with one field error           |
+| unknown route                                  | 404        | none                                               | `NOT_FOUND`                                    |
+| redirects, thrown `Response`s, `status(...)`   | as is      | none                                               | untouched                                      |
+| anything else                                  | 500        | `captureException`                                 | `INTERNAL` with default copy and a `reference` |
+
+Sentry is loaded through a dynamic import of `@sentry/bun` and skipped when it is not installed. Every branch logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log.
+
+### Wire contract
+
+Every 4xx/5xx response produced by the plugin has `Content-Type: application/problem+json` and this shape:
+
+```jsonc
+{
+  "type": "https://example.com/docs/errors/NOT_FOUND",
+  "title": "Video not found",
+  "status": 404,
+  "detail": "The resource you requested does not exist or has been removed.",
+  "instance": "/videos/abc",
+  "reason": "NOT_FOUND", // stable key from the table
+  "metadata": { "entity": "Video", "id": "abc" }, // validated by the entry's schema
+  "reference": "8c1f4d2e…" // Sentry event id, only when captured
+}
+```
+
+Validation failures (422) are a `ValidationProblem`: the same members plus a required `errors` array with one entry per invalid value. `in` uses the OpenAPI location vocabulary (`body`, `path`, `query`, `header`, `cookie`) and `pointer` is a JSON pointer fragment within that location, so clients never need to parse strings:
+
+```jsonc
+{
+  "type": "about:blank",
+  "title": "Invalid input",
+  "status": 422,
+  "detail": "2 fields are invalid: body.name, body.tags[1]",
+  "instance": "/videos",
+  "reason": "INVALID_INPUT",
+  "errors": [
+    { "in": "body", "pointer": "#/name", "detail": "Expected string length greater or equal to 3", "received": "\"\"" },
+    { "in": "body", "pointer": "#/tags/1", "detail": "Expected string", "received": "1" }
+  ]
+}
+```
+
+`title` and `detail` never contain raw exception messages for unexpected errors, `cause` never serializes, and `received` is omitted when any segment of the pointer matches `/password|secret|token|key/i` or the value has no JSON form (missing properties, files), and truncated to `receivedMaxLength` characters otherwise. A response that fails the action's output schema is a server bug, not a client error: it is reported and answered with a 500 `INTERNAL` problem rather than a 422.
+
+### OpenAPI
+
+`action.docs.response` is keyed by status: `200` holds the output schema when one is defined, `422` references the `ValidationProblem` model, and every other status in the effective table (plus 500) references the shared `Problem` model. With `@elysiajs/openapi` this yields `components.schemas.Problem`, `components.schemas.ValidationProblem` and a `$ref` per documented status. `ApiError`, `Problem` and `ValidationProblem` are exported if you need to map problems onto other transports.
 
 ## Telemetry
 

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Validation failures (422) are a `ValidationProblem`, which has the same members 
 }
 ```
 
-Some things never reach the client. `title` and `detail` never contain the raw message of an unexpected error, and `cause` never serializes. `received` is left out when any segment of the pointer matches `/password|secret|token|key/i` or when the value has no JSON form, such as a missing property or a file. Otherwise it is cut off at `receivedMaxLength` characters.
+Some things never reach the client. `title` and `detail` never contain the raw message of an unexpected error, and `cause` never serializes. `received` is left out when any segment of the pointer matches `/password|secret|token|key/i` or when the value has no JSON form, such as a missing property or a file. When an error is reported on an object, properties matching that pattern at any depth are replaced with `"[redacted]"`. Otherwise it is cut off at `receivedMaxLength` characters.
 
 A response that fails the action's output schema is a server bug, not a client error. It is reported and answered with a 500 `INTERNAL` problem, not a 422.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { createProcedure } from "@luukgoossen/elysia-procedures";
 import { Type } from "@sinclair/typebox";
 
 // Create an authentication middleware procedure
-const authProcedure = createProcedure("Ensure Auth", undefined, {
+const authProcedure = createProcedure("Ensure Auth", {
   errors: { table: { UNAUTHORIZED: { status: 401 } } },
 }).build(async ({ ctx }, onError) => {
   // Check auth header
@@ -284,13 +284,13 @@ The package has no opinion on reason names, status codes or metadata shape. It o
 
 ### Declaring errors
 
-Errors live in the `config` of `createProcedure` and in the `details` of `createAction`. Tables merge by key down the chain. The child's entry wins, and the `type` function is inherited when the child does not set one.
+Errors live in the `config` of `createProcedure`, passed as the second argument or as the third after a base procedure, and in the `details` of `createAction`. Tables merge by key down the chain. The child's entry wins, and the `type` function is inherited when the child does not set one.
 
 ```typescript
 import { createProcedure } from "@luukgoossen/elysia-procedures";
 import { Type } from "@sinclair/typebox";
 
-const baseProcedure = createProcedure("Base", undefined, {
+const baseProcedure = createProcedure("Base", {
   errors: {
     // builds the RFC 9457 `type` URI for a reason; defaults to "about:blank"
     type: (reason) => `https://example.com/docs/errors/${reason}`,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
   - [Wire contract](#wire-contract)
   - [OpenAPI](#openapi)
 - [Telemetry](#telemetry)
+- [Type-checking performance](#type-checking-performance)
 - [Acknowledgments](#acknowledgments)
 
 ## Features
@@ -429,6 +430,27 @@ Validation failures (422) are a `ValidationProblem`: the same members plus a req
 ## Telemetry
 
 This package supports telemetry tracing. Both `@sentry/bun` and `@elysiajs/opentelemetry` are defined as optional peer dependencies. If either one is installed, telemetry traces will be made available. If both are installed, `@sentry/bun` takes priority over `@elysiajs/opentelemetry`.
+
+## Type-checking performance
+
+The builder chain is designed to keep the type checker's work per action small: schema constraints are checked structurally instead of against `TObject` (which would evaluate every schema's static type twice), schemas are only re-wrapped when there is something to merge, and `onError` is a single generic signature resolved per call instead of one overload per table entry. With ~250 actions the library itself accounts for well under half a million type instantiations.
+
+The dominant cost in a large server is Elysia's own route typing, which grows faster than linearly with the number of routes registered on **one** instance. When `tsc`, ESLint or the editor become slow, split the registrations into sub-apps and mount them on the main app. Each sub-app needs `problems()` as well so the `Problem` response models resolve; the plugin is named, so Elysia deduplicates it and every error is still handled exactly once:
+
+```typescript
+const products = new Elysia({ prefix: "/products" })
+  .use(problems())
+  .get("/:productId", getProductAction.handle, getProductAction.docs)
+  .post("/:productId/update", updateProductAction.handle, updateProductAction.docs);
+
+const orders = new Elysia({ prefix: "/orders" })
+  .use(problems())
+  .get("/", listOrdersAction.handle, listOrdersAction.docs);
+
+const app = new Elysia().use(problems()).use(products).use(orders).listen(3000);
+```
+
+In a benchmark with 500 actions registered with `.handle` and `.docs`, moving from one chain to sub-apps of 25 routes cut the checker from 6.6M to 3.6M type instantiations and peak memory from 1.1GB to 0.8GB. Splitting the sub-apps over several files additionally lets the editor re-check only the file being edited.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elysia Procedures
 
-A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) with [TypeBox](https://github.com/sinclairzx81/typebox) validation. Build robust API endpoints with reusable middleware, input validation, and full TypeScript support. Inspired by tRPC's procedure pattern for end-to-end type safety.
+A procedure builder for [Elysia](https://elysiajs.com) with [TypeBox](https://github.com/sinclairzx81/typebox) validation. You compose procedures into a chain of middleware, each adding validated input and typed context, and turn the chain into actions that plug into Elysia routes. The pattern is borrowed from tRPC.
 
 ## Table of Contents
 
@@ -25,15 +25,14 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
 
 ## Features
 
-- 🥇 **Elysia** - First class integration with the Elysia framework
-- 🔒 **Type-safe** - Full TypeScript support with inferred types
-- ✅ **Validation** - Built-in schema validation using TypeBox
-- 🧩 **Composable** - Create reusable procedures and middleware
-- 📚 **Documentation** - Co-locate your OpenAPI documentation with the handlers
-- 💾 **Caching** - Dependency-based request-level caching
-- 🚨 **Errors** - Typed error tables, RFC 9457 `application/problem+json` responses and pluggable error reporting
-- 🔭 **Tracing** - OpenTelemetry spans for every action, middleware and handler run
-- 🔗 **tRPC-style** - Familiar procedure-based patterns for type-safe APIs
+- **Elysia.** `action.handle` and `action.docs` drop straight into `.get()` / `.post()` calls.
+- **Typed.** Params, query, body, context and errors are inferred down the chain. Wrong input does not compile.
+- **Validation.** TypeBox schemas validate params, query, body and output.
+- **Composable.** Procedures extend other procedures, and actions reuse them as middleware.
+- **Documentation.** OpenAPI details live next to the handler and `action.docs` emits them.
+- **Caching.** A procedure runs once per request, keyed by the dependencies you name.
+- **Errors.** Typed error tables, RFC 9457 `application/problem+json` responses and pluggable error reporting.
+- **Tracing.** OpenTelemetry spans for every action, middleware and handler run.
 
 ## Installation
 
@@ -59,11 +58,13 @@ import { createProcedure } from "@luukgoossen/elysia-procedures";
 import { Type } from "@sinclair/typebox";
 
 // Create an authentication middleware procedure
-const authProcedure = createProcedure("Ensure Auth").build(async ({ ctx }) => {
+const authProcedure = createProcedure("Ensure Auth", undefined, {
+  errors: { table: { UNAUTHORIZED: { status: 401 } } },
+}).build(async ({ ctx }, onError) => {
   // Check auth header
   const authHeader = ctx.request.headers.get("Authorization");
   if (!authHeader) {
-    throw new Error("Unauthorized");
+    throw onError("UNAUTHORIZED");
   }
 
   // Return user data to be added to context
@@ -126,7 +127,7 @@ const user = await getUserAction.run(context, { params, query, body });
 
 ### Creating a Basic Procedure
 
-A procedure is a reusable foundation for your API endpoints. It can define common parameters, validation schemas, and middleware.
+A procedure is the reusable part of an endpoint. It declares the params, query and body it needs, runs a handler, and whatever that handler returns is merged into the context of everything built on top of it.
 
 ```typescript
 import { createProcedure } from "@luukgoossen/elysia-procedures";
@@ -141,7 +142,7 @@ const baseProcedure = createProcedure("Basic Procedure").build(({ ctx }) => {
 
 ### Adding Schema Validation
 
-You can add TypeBox schemas to validate parameters, query strings, and request bodies:
+TypeBox schemas validate params, query strings and request bodies. A child procedure inherits its parent's schemas and can add properties, but not redeclare one the parent already has.
 
 ```typescript
 const productProcedure = createProcedure("Ensure Product", baseProcedure)
@@ -175,7 +176,7 @@ const productProcedure = createProcedure("Ensure Product", baseProcedure)
 
 ### Creating Actions
 
-Actions represent the actual API endpoints built from procedures:
+An action is an endpoint built from a procedure. It adds an output schema and the handler that does the work:
 
 ```typescript
 const getProductAction = productProcedure
@@ -211,14 +212,16 @@ const getProductAction = productProcedure
 
 ## Integrating with Elysia
 
-This library has first class support for integrating with the Elysia framework through the action.handle function, which expects an Elysia context, and action.docs which returns Elysia-formatted documentation defining the input and output schemas in a type-safe way.
+`action.handle` is an Elysia route handler and `action.docs` is the matching route config: the params, query, body and response schemas, and the OpenAPI detail. Pass both to a route and Elysia validates the input and documents the endpoint.
 
-With tracing enabled on the `procedures()` plugin it also adds OpenTelemetry spans to procedure and action runs, nested under Elysia's OpenTelemetry plugin (or any other SDK), providing step by step information about the executed chain. See [Tracing](#tracing).
+Mount the `procedures()` plugin on the root app to get `application/problem+json` error responses (see [Errors](#errors)) and, when enabled, an OpenTelemetry span per step of the chain (see [Tracing](#tracing)).
 
 ```typescript
 import { Elysia } from "elysia";
+import { procedures } from "@luukgoossen/elysia-procedures";
 
 const app = new Elysia()
+  .use(procedures())
   .get("/products/:productId", getProductAction.handle, getProductAction.docs)
   .post(
     "/products/:productId/update",
@@ -230,7 +233,7 @@ const app = new Elysia()
 
 ## Caching
 
-This library supports request-level caching to ensure that procedures are executed only once per http request. To enable caching for a procedure, you can supply an array of dependencies to the procedure builder.
+A procedure used by several actions, or by several middlewares in one chain, would run once per use. Caching makes it run once per request instead. Turn it on by giving the builder a function that returns the procedure's dependencies.
 
 ```typescript
 import { createProcedure } from "@luukgoossen/elysia-procedures";
@@ -249,7 +252,7 @@ const baseProcedure = createProcedure("Basic Procedure")
   });
 ```
 
-Any array will enable caching for the procedure, but if input variables might change between different calls to the same procedure for the same request, it is important to include their keys in the array.
+Any array turns caching on, even an empty one. If the same procedure can be called with different params, query or body within one request, return those values from the function so each combination gets its own cache entry. Caches are applied per-request.
 
 ```typescript
 import { createProcedure } from "@luukgoossen/elysia-procedures";
@@ -275,13 +278,13 @@ const baseProcedure = createProcedure("Basic Procedure")
 
 ## Errors
 
-Errors are a first-class part of a procedure chain. You declare an **error table** once, throw errors through the typed `onError` factory injected into every handler, and let the `procedures()` plugin turn everything that escapes a route into an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) `application/problem+json` response.
+You declare an error table once, throw errors through the typed `onError` factory every handler receives, and let the `procedures()` plugin turn everything that escapes a route into an [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) `application/problem+json` response.
 
-The package has no opinion on reason names, status mapping or metadata shape; it only provides the mechanics.
+The package has no opinion on reason names, status codes or metadata shape. It only provides the mechanics.
 
 ### Declaring errors
 
-Errors live in the `config` of `createProcedure` (and in the `details` of `createAction`). Tables are merged **by key** down the chain: the child wins, and the `type` function is inherited when the child does not set one.
+Errors live in the `config` of `createProcedure` and in the `details` of `createAction`. Tables merge by key down the chain. The child's entry wins, and the `type` function is inherited when the child does not set one.
 
 ```typescript
 import { createProcedure } from "@luukgoossen/elysia-procedures";
@@ -311,7 +314,7 @@ const adminProcedure = createProcedure("Admin", baseProcedure, {
 }).build();
 ```
 
-Each entry has a `status`, an optional TypeBox `metadata` schema (required when calling `onError` if present), and an optional `title` / `detail` that is either a string or a function of the validated metadata. Inside a plain object literal the metadata parameter of those functions must be annotated; wrap the entry in `defineError(...)` to have it inferred from the schema:
+Each entry has a `status`, an optional TypeBox `metadata` schema, and an optional `title` and `detail`. When an entry declares `metadata`, `onError` requires it. `title` and `detail` are either strings or functions of the validated metadata. Inside a plain object literal the metadata parameter of those functions has to be annotated by hand. Wrap the entry in `defineError(...)` and it is inferred from the schema:
 
 ```typescript
 import { defineError } from "@luukgoossen/elysia-procedures";
@@ -323,13 +326,13 @@ NOT_FOUND: defineError({
 }),
 ```
 
-Four entries are always present, callable from every handler, and can be overridden by key but not removed: `INTERNAL` (500), `INVALID_INPUT` (422), `MALFORMED_REQUEST` (400) and `NOT_FOUND` (404). The plugin uses them for failures that are not `ApiError`s.
+Four entries are always present and callable from every handler: `INTERNAL` (500), `INVALID_INPUT` (422), `MALFORMED_REQUEST` (400) and `NOT_FOUND` (404). You can override them by key but not remove them. The plugin uses them for failures that are not `ApiError`s.
 
-Keep `status` values literal (inline object literals or `defineError`) so the documented response statuses stay typed; a table stored in a variable without `as const` widens them to `number`.
+Keep `status` values literal, either as inline object literals or through `defineError`. A table stored in a variable without `as const` widens them to `number`, and then `action.docs` can no longer type the response statuses.
 
 ### Throwing errors
 
-Every handler and middleware receives `onError` as its **second argument**. It is typed from the effective table: unknown reasons do not compile, and metadata is required exactly when the entry declares a schema.
+Every handler and middleware receives `onError` as its second argument. It is typed from the effective table, so an unknown reason does not compile, and metadata is required exactly when the entry declares a schema.
 
 ```typescript
 const getVideo = baseProcedure
@@ -348,11 +351,11 @@ const getVideo = baseProcedure
   });
 ```
 
-`onError(reason, metadata?, options?)` returns an `ApiError` with public `status`, `reason`, `metadata`, `title`, `detail`, `type` and `cause`; you throw it. Copy is resolved as `options` → entry function or string → fallback (`title` is the reason in Title Case, no `detail`). Passing metadata that does not match the schema throws a plain `TypeError`, since that is a programming error rather than an API error.
+`onError(reason, metadata?, options?)` returns an `ApiError` with public `status`, `reason`, `metadata`, `title`, `detail`, `type` and `cause`. You throw it. The `title` and `detail` come from `options` first, then from the entry's string or function, and finally from a fallback: the reason in Title Case for `title`, nothing for `detail`. Metadata that does not match the schema throws a plain `TypeError`, because that is a bug in the handler, not an API error.
 
 ### The `procedures()` plugin
 
-`procedures()` is the library's Elysia integration. Mount it **once, on the root app, before any sub-apps**. It registers the `Problem` and `ValidationProblem` models that `action.docs` reference and a global `onError` hook that serializes every failure. Elysia applies global hooks to every route registered after them, at any nesting depth, so sub-apps need nothing; a sub-app `.use()`d *before* the plugin is not covered.
+`procedures()` is the Elysia plugin. Mount it once, on the root app, before any sub-apps. It registers the `Problem` and `ValidationProblem` models that `action.docs` reference and a global `onError` hook that serializes every failure. Elysia applies global hooks to every route registered after them, at any nesting depth, so sub-apps need nothing. A sub-app `.use()`d before the plugin is not covered.
 
 ```typescript
 import { Elysia } from "elysia";
@@ -362,13 +365,13 @@ import * as Sentry from "@sentry/bun";
 const app = new Elysia()
   .use(
     procedures({
-      // the wire contract: same shape as the procedure config, used for the problems the plugin builds itself
+      // same shape as the procedure config; used for the problems the plugin builds itself
       errors: {
         type: (reason) => `https://example.com/docs/errors/${reason}`,
         // max characters of a field's `received` value echoed back; default 200
         receivedMaxLength: 200,
       },
-      // policy: how handled failures are reported, logged and traced
+      // how handled failures are reported, logged and traced
       observability: {
         // reports failures and yields the `reference`; default: none
         errorReporting: sentryReporter(Sentry, { captureClientErrors: "warn" }),
@@ -393,31 +396,40 @@ const app = new Elysia()
 | redirects, thrown `Response`s, `status(...)`                  | as is      | untouched                               |
 | anything else, including a response failing the output schema | 500        | `INTERNAL` with default copy            |
 
-Reporting is a separate policy and off by default: nothing is captured and problems carry no `reference`. `sentryReporter(Sentry, options)` takes the Sentry SDK you initialized (any `@sentry/*` package exposing `captureException` and `captureMessage`) and captures every 5xx problem as an exception (Sentry follows the `cause` chain) and, with `captureClientErrors`, 4xx `ApiError`s as messages. Any `(error, problem) => string | undefined` works as a reporter, so other trackers plug in the same way. Whatever the reporter returns becomes the problem's `reference`. Every handled failure logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log, and only for 5xx.
+Reporting is off by default. Nothing is captured and problems carry no `reference`. `sentryReporter(Sentry, options)` takes the Sentry SDK you initialized, meaning any `@sentry/*` package with `captureException` and `captureMessage`. It captures every 5xx problem as an exception, and Sentry follows the `cause` chain from there. With `captureClientErrors` it also captures 4xx `ApiError`s as messages. Any `(error, problem) => string | undefined` works as a reporter, so other trackers plug in the same way. Whatever the reporter returns becomes the problem's `reference`.
 
-Without the plugin nothing fails loudly, but you lose the contract: a thrown `ApiError` becomes a plain-text response with the right status, an unexpected `Error` is answered with its raw message (Elysia's default), validation failures use Elysia's own JSON shape, and the OpenAPI spec references `Problem` schemas that are never emitted. The `.get(path, action.handle, action.docs)` pattern above assumes the plugin is mounted.
+Every handled failure logs one structured line, `{ status, reason, instance, method, reference?, message? }`. The raw `message` only ever appears in the log, and only for 5xx.
+
+Without the plugin nothing fails loudly, but you lose the contract. A thrown `ApiError` becomes a plain-text response with the right status. An unexpected `Error` is answered with its raw message, which is Elysia's default. Validation failures use Elysia's own JSON shape, and the OpenAPI spec references `Problem` schemas that are never emitted. The `.get(path, action.handle, action.docs)` pattern above assumes the plugin is mounted.
 
 #### Bringing your own handler
 
-`procedures()` is a composition of exported pieces, so an app with its own `onError` (HTML error pages, another error tracker, a different logging stack) can keep the wire contract without the policy:
+`procedures()` is built from exported pieces. An app that already has its own `onError`, for HTML error pages, another error tracker or a different logging stack, can keep the wire contract and skip the rest:
 
 - `procedureModels()` registers the `Problem` and `ValidationProblem` models that `action.docs` reference and `ApiError` as a known error. Mount it instead of `procedures()`.
-- `resolveProblem(code, error, { instance?, errors?, receivedMaxLength? })` is the behaviour table above as a pure function: no reporting, no logging, never a raw message, and `undefined` for values that should pass through.
-- `problemResponse(problem)` serializes to `application/problem+json`.
-- `sentryReporter(sentry, options)` is the Sentry reporter, reusable on its own.
-- `configureTracing(options)` turns on tracing without the plugin, e.g. for actions run outside Elysia.
+- `resolveProblem(code, error, { instance?, errors?, receivedMaxLength? })` is the table above as a pure function. No reporting, no logging, never a raw message, and `undefined` for values that should pass through.
+- `problemResponse(problem)` serializes a problem to an `application/problem+json` response.
+- `sentryReporter(sentry, options)` is the Sentry reporter on its own.
+- `configureTracing(options)` turns on tracing without the plugin, for example for actions run outside Elysia.
 
 ```typescript
 import { Elysia } from "elysia";
-import { procedureModels, resolveProblem, problemResponse } from "@luukgoossen/elysia-procedures";
+import {
+  procedureModels,
+  resolveProblem,
+  problemResponse,
+} from "@luukgoossen/elysia-procedures";
 
 const app = new Elysia()
   .use(procedureModels())
   .onError(async ({ code, error, request }) => {
-    const problem = resolveProblem(code, error, { instance: new URL(request.url).pathname });
+    const problem = resolveProblem(code, error, {
+      instance: new URL(request.url).pathname,
+    });
     if (!problem) return; // redirect or early return, let Elysia handle it
 
-    const reference = problem.status >= 500 ? await myTracker.capture(error) : undefined;
+    const reference =
+      problem.status >= 500 ? await myTracker.capture(error) : undefined;
     return problemResponse({ ...problem, reference });
   });
 ```
@@ -435,11 +447,11 @@ Every 4xx/5xx response produced by the plugin has `Content-Type: application/pro
   "instance": "/videos/abc",
   "reason": "NOT_FOUND", // stable key from the table
   "metadata": { "entity": "Video", "id": "abc" }, // validated by the entry's schema
-  "reference": "8c1f4d2e…" // whatever the reporter returned, e.g. a Sentry event id; only when captured
+  "reference": "8c1f4d2e…", // whatever the reporter returned, e.g. a Sentry event id; only when captured
 }
 ```
 
-Validation failures (422) are a `ValidationProblem`: the same members plus a required `errors` array with one entry per invalid value. `in` uses the OpenAPI location vocabulary (`body`, `path`, `query`, `header`, `cookie`) and `pointer` is a JSON pointer fragment within that location, so clients never need to parse strings:
+Validation failures (422) are a `ValidationProblem`, which has the same members plus a required `errors` array with one entry per invalid value. `in` is the OpenAPI location (`body`, `path`, `query`, `header` or `cookie`) and `pointer` is a JSON pointer fragment within that location, so a client can map each error to a field without parsing strings:
 
 ```jsonc
 {
@@ -450,21 +462,33 @@ Validation failures (422) are a `ValidationProblem`: the same members plus a req
   "instance": "/videos",
   "reason": "INVALID_INPUT",
   "errors": [
-    { "in": "body", "pointer": "#/name", "detail": "Expected string length greater or equal to 3", "received": "\"\"" },
-    { "in": "body", "pointer": "#/tags/1", "detail": "Expected string", "received": "1" }
-  ]
+    {
+      "in": "body",
+      "pointer": "#/name",
+      "detail": "Expected string length greater or equal to 3",
+      "received": "\"\"",
+    },
+    {
+      "in": "body",
+      "pointer": "#/tags/1",
+      "detail": "Expected string",
+      "received": "1",
+    },
+  ],
 }
 ```
 
-`title` and `detail` never contain raw exception messages for unexpected errors, `cause` never serializes, and `received` is omitted when any segment of the pointer matches `/password|secret|token|key/i` or the value has no JSON form (missing properties, files), and truncated to `receivedMaxLength` characters otherwise. A response that fails the action's output schema is a server bug, not a client error: it is reported and answered with a 500 `INTERNAL` problem rather than a 422.
+Some things never reach the client. `title` and `detail` never contain the raw message of an unexpected error, and `cause` never serializes. `received` is left out when any segment of the pointer matches `/password|secret|token|key/i` or when the value has no JSON form, such as a missing property or a file. Otherwise it is cut off at `receivedMaxLength` characters.
+
+A response that fails the action's output schema is a server bug, not a client error. It is reported and answered with a 500 `INTERNAL` problem, not a 422.
 
 ### OpenAPI
 
-`action.docs.response` is keyed by status: `200` holds the output schema when one is defined, `422` references the `ValidationProblem` model, and every other status in the effective table (plus 500) references the shared `Problem` model. With `@elysiajs/openapi` this yields `components.schemas.Problem`, `components.schemas.ValidationProblem` and a `$ref` per documented status. `ApiError`, `Problem` and `ValidationProblem` are exported if you need to map problems onto other transports.
+`action.docs.response` is keyed by status. `200` holds the output schema when one is defined, `422` references the `ValidationProblem` model, and every other status in the effective table, plus 500, references the shared `Problem` model. With `@elysiajs/openapi` this yields `components.schemas.Problem`, `components.schemas.ValidationProblem` and a `$ref` per documented status. `ApiError`, `Problem` and `ValidationProblem` are exported in case you need to map problems onto another transport.
 
 ## Tracing
 
-Tracing is built on the [OpenTelemetry API](https://www.npmjs.com/package/@opentelemetry/api) and nothing else, so it works with whichever SDK registers the global tracer provider: `@elysiajs/opentelemetry`, `@sentry/bun` (which is itself built on OpenTelemetry), or the OpenTelemetry Node SDK directly. Spans nest under the active span, so with Elysia's plugin every procedure run shows up inside its request span. Without a provider the API is a no-op.
+Tracing uses the [OpenTelemetry API](https://www.npmjs.com/package/@opentelemetry/api) and nothing else, so it works with whichever SDK registers the global tracer provider. That can be `@elysiajs/opentelemetry`, `@sentry/bun` (itself built on OpenTelemetry) or the OpenTelemetry Node SDK directly. Spans nest under the active span, so with Elysia's plugin every procedure run shows up inside its request span. Without a provider the API does nothing.
 
 Tracing is off until you turn it on through the plugin:
 
@@ -474,57 +498,66 @@ import { opentelemetry } from "@elysiajs/opentelemetry";
 import { trace } from "@opentelemetry/api";
 import { procedures } from "@luukgoossen/elysia-procedures";
 
-const app = new Elysia()
-  .use(opentelemetry())
-  .use(
-    procedures({
-      observability: {
-        // true for the defaults, or:
-        tracing: {
-          // a tracer of your own; default: the global provider's tracer for this package
-          tracer: trace.getTracer("my-service"),
-          // which span types to emit; all default to true
-          spans: { input: false, output: false },
-          // attributes added to every span
-          attributes: { "service.layer": "api" },
-        },
+const app = new Elysia().use(opentelemetry()).use(
+  procedures({
+    observability: {
+      // true for the defaults, or:
+      tracing: {
+        // a tracer of your own; default: the global provider's tracer for this package
+        tracer: trace.getTracer("my-service"),
+        // which span types to emit; all default to true
+        spans: { input: false, output: false },
+        // attributes added to every span
+        attributes: { "service.layer": "api" },
       },
-    }),
-  );
+    },
+  }),
+);
 ```
 
-One span is emitted per step of a run. Every span carries `procedure.type`, `procedure.name`, the `attributes` from the action's or procedure's `tracing` config, and `sentry.op` (`procedure.<type>`), which Sentry reads as the operation and other backends ignore. The span name is the action's or procedure's `tracing.name`, or its name.
+One span per step of a run. Every span carries `procedure.type`, `procedure.name`, the `attributes` from the action's or procedure's `tracing` config, and `sentry.op` set to `procedure.<type>`, which Sentry reads as the operation and other backends ignore. The span name is the action's or procedure's `tracing.name`, falling back to its name.
 
-| type         | wraps                                                     | extra attributes                              |
-| ------------ | --------------------------------------------------------- | --------------------------------------------- |
-| `action`     | one `action.handle()` or `action.run()` call              |                                               |
-| `middleware` | one procedure handler run                                 | `procedure.cache.hit` or `procedure.cache`    |
-| `handler`    | the action's own handler, after its middlewares           |                                               |
-| `input`      | input validation in `action.run()`                        |                                               |
-| `output`     | output validation in `action.run()`                       |                                               |
+| type         | wraps                                           | extra attributes                           |
+| ------------ | ----------------------------------------------- | ------------------------------------------ |
+| `action`     | one `action.handle()` or `action.run()` call    |                                            |
+| `middleware` | one procedure handler run                       | `procedure.cache.hit` or `procedure.cache` |
+| `handler`    | the action's own handler, after its middlewares |                                            |
+| `input`      | input validation in `action.run()`              |                                            |
+| `output`     | output validation in `action.run()`             |                                            |
 
-Spans always end, also when the step throws. An unexpected error or a 5xx `ApiError` records the exception and sets the span status to error; a 4xx `ApiError` is an expected outcome and only sets `procedure.error.reason` and `procedure.error.status`.
+Spans always end, also when the step throws. An unexpected error or a 5xx `ApiError` records the exception and sets the span status to error. A 4xx `ApiError` is an expected outcome and only sets `procedure.error.reason` and `procedure.error.status`.
 
-`configureTracing(options | boolean)` is what the plugin calls and is exported for running actions outside Elysia (scripts, queues). Since it configures the package globally, the last call wins; mount `procedures()` once.
+`configureTracing(options | boolean)` is what the plugin calls. It is exported for running actions outside Elysia, in scripts or queue workers. It configures the package globally and the last call wins, which is one more reason to mount `procedures()` once.
 
 ## Type-checking performance
 
-The builder chain is designed to keep the type checker's work per action small: schema constraints are checked structurally instead of against `TObject` (which would evaluate every schema's static type twice), schemas are only re-wrapped when there is something to merge, and `onError` is a single generic signature resolved per call instead of one overload per table entry. With ~250 actions the library itself accounts for well under half a million type instantiations.
+The builder chain keeps the type checker's work per action small. Schema constraints are checked structurally instead of against `TObject`, which would evaluate every schema's static type twice. Schemas are only re-wrapped when there is something to merge. `onError` is one generic signature resolved per call instead of one overload per table entry. With around 250 actions the library itself accounts for well under half a million type instantiations.
 
-The dominant cost in a large server is Elysia's own route typing, which grows faster than linearly with the number of routes registered on **one** instance. When `tsc`, ESLint or the editor become slow, split the registrations into sub-apps and mount them on the main app. The sub-apps need nothing extra: `procedures()` on the root covers them at runtime, and `action.docs` typechecks on any instance.
+The dominant cost in a large server is Elysia's own route typing, which grows faster than linearly with the number of routes registered on one instance. When `tsc`, ESLint or the editor get slow, split the registrations into sub-apps and mount those on the main app. The sub-apps need nothing extra. `procedures()` on the root covers them at runtime, and `action.docs` typechecks on any instance.
 
 ```typescript
 const products = new Elysia({ prefix: "/products" })
   .get("/:productId", getProductAction.handle, getProductAction.docs)
-  .post("/:productId/update", updateProductAction.handle, updateProductAction.docs);
+  .post(
+    "/:productId/update",
+    updateProductAction.handle,
+    updateProductAction.docs,
+  );
 
-const orders = new Elysia({ prefix: "/orders" })
-  .get("/", listOrdersAction.handle, listOrdersAction.docs);
+const orders = new Elysia({ prefix: "/orders" }).get(
+  "/",
+  listOrdersAction.handle,
+  listOrdersAction.docs,
+);
 
-const app = new Elysia().use(procedures()).use(products).use(orders).listen(3000);
+const app = new Elysia()
+  .use(procedures())
+  .use(products)
+  .use(orders)
+  .listen(3000);
 ```
 
-In a benchmark with 500 actions registered with `.handle` and `.docs`, moving from one chain to sub-apps of 25 routes cut the checker from 6.6M to 3.6M type instantiations and peak memory from 1.1GB to 0.8GB. Splitting the sub-apps over several files additionally lets the editor re-check only the file being edited.
+In a benchmark with 500 actions registered with `.handle` and `.docs`, moving from one chain to sub-apps of 25 routes cut the checker from 6.6M to 3.6M type instantiations and peak memory from 1.1GB to 0.8GB. Put the sub-apps in separate files and the editor only re-checks the file you are editing.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ const getVideo = baseProcedure
 
 ### The `problems()` plugin
 
-Mount the plugin on your Elysia app. It registers the `Problem` model (which `action.docs` references) and an `onError` hook that serializes every failure. It is idempotent, so use it on every instance that mounts actions.
+Mount the plugin **once, on the root app, before any sub-apps**. It registers the `Problem` and `ValidationProblem` models that `action.docs` reference and a global `onError` hook that serializes every failure. Elysia applies global hooks to every route registered after them, at any nesting depth, so sub-apps need nothing; a sub-app `.use()`d *before* the plugin is not covered.
 
 ```typescript
 import { Elysia } from "elysia";
@@ -386,6 +386,8 @@ const app = new Elysia()
 | anything else                                  | 500        | `captureException`                                 | `INTERNAL` with default copy and a `reference` |
 
 Sentry is loaded through a dynamic import of `@sentry/bun` and skipped when it is not installed. Every branch logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log.
+
+Without the plugin nothing fails loudly, but you lose the contract: a thrown `ApiError` becomes a plain-text response with the right status, an unexpected `Error` is answered with its raw message (Elysia's default), validation failures use Elysia's own JSON shape, and the OpenAPI spec references `Problem` schemas that are never emitted. The `.get(path, action.handle, action.docs)` pattern above assumes the plugin is mounted.
 
 ### Wire contract
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
   - [The `procedures()` plugin](#the-procedures-plugin)
   - [Wire contract](#wire-contract)
   - [OpenAPI](#openapi)
-- [Telemetry](#telemetry)
+- [Tracing](#tracing)
 - [Type-checking performance](#type-checking-performance)
 - [Acknowledgments](#acknowledgments)
 
@@ -31,7 +31,8 @@ A type-safe, composable procedure builder for [Elysia](https://elysiajs.com) wit
 - 🧩 **Composable** - Create reusable procedures and middleware
 - 📚 **Documentation** - Co-locate your OpenAPI documentation with the handlers
 - 💾 **Caching** - Dependency-based request-level caching
-- 🚨 **Errors** - Typed error tables, RFC 9457 `application/problem+json` responses and a safe Sentry policy
+- 🚨 **Errors** - Typed error tables, RFC 9457 `application/problem+json` responses and pluggable error reporting
+- 🔭 **Tracing** - OpenTelemetry spans for every action, middleware and handler run
 - 🔗 **tRPC-style** - Familiar procedure-based patterns for type-safe APIs
 
 ## Installation
@@ -212,7 +213,7 @@ const getProductAction = productProcedure
 
 This library has first class support for integrating with the Elysia framework through the action.handle function, which expects an Elysia context, and action.docs which returns Elysia-formatted documentation defining the input and output schemas in a type-safe way.
 
-It also hooks into Elysia's OpenTelemetry plugin to add tracing to procedure and action runs, providing step by step information about the executed chain.
+With tracing enabled on the `procedures()` plugin it also adds OpenTelemetry spans to procedure and action runs, nested under Elysia's OpenTelemetry plugin (or any other SDK), providing step by step information about the executed chain. See [Tracing](#tracing).
 
 ```typescript
 import { Elysia } from "elysia";
@@ -356,6 +357,7 @@ const getVideo = baseProcedure
 ```typescript
 import { Elysia } from "elysia";
 import { procedures, sentryReporter } from "@luukgoossen/elysia-procedures";
+import * as Sentry from "@sentry/bun";
 
 const app = new Elysia()
   .use(
@@ -366,12 +368,14 @@ const app = new Elysia()
         // max characters of a field's `received` value echoed back; default 200
         receivedMaxLength: 200,
       },
-      // policy: how handled failures are reported and logged
+      // policy: how handled failures are reported, logged and traced
       observability: {
-        // reports failures and yields the `reference`; default: sentryReporter()
-        errorReporting: sentryReporter({ captureClientErrors: "warn" }),
+        // reports failures and yields the `reference`; default: none
+        errorReporting: sentryReporter(Sentry, { captureClientErrors: "warn" }),
         // default console.warn for 4xx and console.error for 5xx
         logging: (level, fields) => logger[level](fields),
+        // OpenTelemetry spans for every run; default: off
+        tracing: true,
       },
     }),
   )
@@ -389,7 +393,7 @@ const app = new Elysia()
 | redirects, thrown `Response`s, `status(...)`                  | as is      | untouched                               |
 | anything else, including a response failing the output schema | 500        | `INTERNAL` with default copy            |
 
-Reporting is a separate policy. The default `sentryReporter()` captures every 5xx problem as an exception (Sentry follows the `cause` chain) and, with `captureClientErrors`, 4xx `ApiError`s as messages; it loads `@sentry/bun` through a dynamic import and does nothing when it is not installed. Whatever the reporter returns becomes the problem's `reference`. Every handled failure logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log, and only for 5xx.
+Reporting is a separate policy and off by default: nothing is captured and problems carry no `reference`. `sentryReporter(Sentry, options)` takes the Sentry SDK you initialized (any `@sentry/*` package exposing `captureException` and `captureMessage`) and captures every 5xx problem as an exception (Sentry follows the `cause` chain) and, with `captureClientErrors`, 4xx `ApiError`s as messages. Any `(error, problem) => string | undefined` works as a reporter, so other trackers plug in the same way. Whatever the reporter returns becomes the problem's `reference`. Every handled failure logs a structured line `{ status, reason, instance, method, reference?, message? }`; the raw `message` only ever appears in the log, and only for 5xx.
 
 Without the plugin nothing fails loudly, but you lose the contract: a thrown `ApiError` becomes a plain-text response with the right status, an unexpected `Error` is answered with its raw message (Elysia's default), validation failures use Elysia's own JSON shape, and the OpenAPI spec references `Problem` schemas that are never emitted. The `.get(path, action.handle, action.docs)` pattern above assumes the plugin is mounted.
 
@@ -400,7 +404,8 @@ Without the plugin nothing fails loudly, but you lose the contract: a thrown `Ap
 - `procedureModels()` registers the `Problem` and `ValidationProblem` models that `action.docs` reference and `ApiError` as a known error. Mount it instead of `procedures()`.
 - `resolveProblem(code, error, { instance?, errors?, receivedMaxLength? })` is the behaviour table above as a pure function: no reporting, no logging, never a raw message, and `undefined` for values that should pass through.
 - `problemResponse(problem)` serializes to `application/problem+json`.
-- `sentryReporter(options)` is the default reporter, reusable on its own.
+- `sentryReporter(sentry, options)` is the Sentry reporter, reusable on its own.
+- `configureTracing(options)` turns on tracing without the plugin, e.g. for actions run outside Elysia.
 
 ```typescript
 import { Elysia } from "elysia";
@@ -430,7 +435,7 @@ Every 4xx/5xx response produced by the plugin has `Content-Type: application/pro
   "instance": "/videos/abc",
   "reason": "NOT_FOUND", // stable key from the table
   "metadata": { "entity": "Video", "id": "abc" }, // validated by the entry's schema
-  "reference": "8c1f4d2e…" // Sentry event id, only when captured
+  "reference": "8c1f4d2e…" // whatever the reporter returned, e.g. a Sentry event id; only when captured
 }
 ```
 
@@ -457,9 +462,50 @@ Validation failures (422) are a `ValidationProblem`: the same members plus a req
 
 `action.docs.response` is keyed by status: `200` holds the output schema when one is defined, `422` references the `ValidationProblem` model, and every other status in the effective table (plus 500) references the shared `Problem` model. With `@elysiajs/openapi` this yields `components.schemas.Problem`, `components.schemas.ValidationProblem` and a `$ref` per documented status. `ApiError`, `Problem` and `ValidationProblem` are exported if you need to map problems onto other transports.
 
-## Telemetry
+## Tracing
 
-This package supports telemetry tracing. Both `@sentry/bun` and `@elysiajs/opentelemetry` are defined as optional peer dependencies. If either one is installed, telemetry traces will be made available. If both are installed, `@sentry/bun` takes priority over `@elysiajs/opentelemetry`.
+Tracing is built on the [OpenTelemetry API](https://www.npmjs.com/package/@opentelemetry/api) and nothing else, so it works with whichever SDK registers the global tracer provider: `@elysiajs/opentelemetry`, `@sentry/bun` (which is itself built on OpenTelemetry), or the OpenTelemetry Node SDK directly. Spans nest under the active span, so with Elysia's plugin every procedure run shows up inside its request span. Without a provider the API is a no-op.
+
+Tracing is off until you turn it on through the plugin:
+
+```typescript
+import { Elysia } from "elysia";
+import { opentelemetry } from "@elysiajs/opentelemetry";
+import { trace } from "@opentelemetry/api";
+import { procedures } from "@luukgoossen/elysia-procedures";
+
+const app = new Elysia()
+  .use(opentelemetry())
+  .use(
+    procedures({
+      observability: {
+        // true for the defaults, or:
+        tracing: {
+          // a tracer of your own; default: the global provider's tracer for this package
+          tracer: trace.getTracer("my-service"),
+          // which span types to emit; all default to true
+          spans: { input: false, output: false },
+          // attributes added to every span
+          attributes: { "service.layer": "api" },
+        },
+      },
+    }),
+  );
+```
+
+One span is emitted per step of a run. Every span carries `procedure.type`, `procedure.name`, the `attributes` from the action's or procedure's `tracing` config, and `sentry.op` (`procedure.<type>`), which Sentry reads as the operation and other backends ignore. The span name is the action's or procedure's `tracing.name`, or its name.
+
+| type         | wraps                                                     | extra attributes                              |
+| ------------ | --------------------------------------------------------- | --------------------------------------------- |
+| `action`     | one `action.handle()` or `action.run()` call              |                                               |
+| `middleware` | one procedure handler run                                 | `procedure.cache.hit` or `procedure.cache`    |
+| `handler`    | the action's own handler, after its middlewares           |                                               |
+| `input`      | input validation in `action.run()`                        |                                               |
+| `output`     | output validation in `action.run()`                       |                                               |
+
+Spans always end, also when the step throws. An unexpected error or a 5xx `ApiError` records the exception and sets the span status to error; a 4xx `ApiError` is an expected outcome and only sets `procedure.error.reason` and `procedure.error.status`.
+
+`configureTracing(options | boolean)` is what the plugin calls and is exported for running actions outside Elysia (scripts, queues). Since it configures the package globally, the last call wins; mount `procedures()` once.
 
 ## Type-checking performance
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,6 +1,6 @@
 # Type-checking benchmark
 
-Generates a consumer file with N actions (chained procedures, error tables, Elysia registration) and reports `tsc` diagnostics, to catch regressions in the type-level cost per action.
+Generates a consumer file with N actions (chained procedures, error tables, Elysia registration) and reports `tsc` diagnostics. Run it before and after a change to the types to see whether the cost per action moved.
 
 ```bash
 cd bench
@@ -10,4 +10,4 @@ SPLIT=25 ./measure.sh 500              # 500 routes in sub-apps of 25
 FLAGS=no-body,no-output ./measure.sh 250
 ```
 
-Flags: `no-app`, `no-params`, `no-query`, `no-body`, `no-output`, `no-details`, `no-errors`, `no-onerror`. Add `--generateTrace trace` to the `tsc` call in `measure.sh` and inspect `trace/types.json` to see which types dominate.
+Flags: `no-app`, `no-params`, `no-query`, `no-body`, `no-output`, `no-details`, `no-errors`, `no-onerror`. To find out which types dominate, add `--generateTrace trace` to the `tsc` call in `measure.sh` and inspect `trace/types.json`.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,13 @@
+# Type-checking benchmark
+
+Generates a consumer file with N actions (chained procedures, error tables, Elysia registration) and reports `tsc` diagnostics, to catch regressions in the type-level cost per action.
+
+```bash
+cd bench
+./measure.sh 250                       # one Elysia chain with 250 routes
+FLAGS=no-app ./measure.sh 250          # actions only, no Elysia app
+SPLIT=25 ./measure.sh 500              # 500 routes in sub-apps of 25
+FLAGS=no-body,no-output ./measure.sh 250
+```
+
+Flags: `no-app`, `no-params`, `no-query`, `no-body`, `no-output`, `no-details`, `no-errors`, `no-onerror`. Add `--generateTrace trace` to the `tsc` call in `measure.sh` and inspect `trace/types.json` to see which types dominate.

--- a/bench/gen.ts
+++ b/bench/gen.ts
@@ -7,7 +7,7 @@ lines.push(`import { Elysia } from 'elysia'`)
 lines.push(`import { Type } from '@sinclair/typebox'`)
 lines.push(`import { createProcedure, defineError, problems } from '../src/index'`)
 lines.push(`
-const base = createProcedure('Base', undefined, {
+const base = createProcedure('Base', {
   errors: {
     type: r => 'https://x/' + r,
     table: {

--- a/bench/gen.ts
+++ b/bench/gen.ts
@@ -1,0 +1,67 @@
+// generates a consumer-like file with N actions, see README.md
+const N = Number(process.argv[2] ?? 250)
+const F = new Set((process.env.FLAGS ?? '').split(',').filter(Boolean))
+const has = (f: string) => !F.has('no-' + f)
+const lines: string[] = []
+lines.push(`import { Elysia } from 'elysia'`)
+lines.push(`import { Type } from '@sinclair/typebox'`)
+lines.push(`import { createProcedure, defineError, problems } from '../src/index'`)
+lines.push(`
+const base = createProcedure('Base', undefined, {
+  errors: {
+    type: r => 'https://x/' + r,
+    table: {
+      FORBIDDEN: { status: 403, title: 'Forbidden' },
+      CONFLICT: defineError({ status: 409, metadata: Type.Object({ id: Type.String() }), title: m => m.id }),
+      UPSTREAM: { status: 502 },
+    },
+  },
+}).build(({ ctx }) => ({ requestTime: new Date() }))
+
+const auth = createProcedure('Auth', base).build(async ({ ctx }, onError) => {
+  if (!ctx.request.headers.get('authorization')) throw onError('FORBIDDEN')
+  return { user: { id: '1', name: 'x', role: 'admin' as const } }
+})
+
+const entity = createProcedure('Entity', auth)
+  .params(Type.Object({ entityId: Type.String() }))
+  .query(Type.Object({ include: Type.Optional(Type.String()), page: Type.Optional(Type.Number()) }))
+  .cache(({ params }) => [params.entityId])
+  .build(({ params }) => ({ entity: { id: params.entityId, owner: 'me' } }))
+`)
+for (let i = 0; i < N; i++) {
+  const proc = i % 3 === 0 ? 'base' : i % 3 === 1 ? 'auth' : 'entity'
+  const details = !has('details') ? '' : has('errors')
+    ? `, { tags: ['t${i % 10}'], errors: { table: { E${i}: { status: ${400 + (i % 50)}, title: 'e${i}' } } } }`
+    : `, { tags: ['t${i % 10}'] }`
+  lines.push(`
+export const action${i} = ${proc}
+  .createAction('Action ${i}'${details})
+  ${has('params') ? `.params(Type.Object({ p${i}: Type.String() }))` : ''}
+  ${has('query') ? `.query(Type.Object({ q${i}: Type.Optional(Type.Number()) }))` : ''}
+  ${has('body') ? `.body(Type.Object({ name: Type.String(), nested: Type.Object({ a: Type.Number(), b: Type.Array(Type.String()) }), flag: Type.Optional(Type.Boolean()) }))` : ''}
+  ${has('output') ? `.output(Type.Object({ id: Type.String(), name: Type.String(), count: Type.Number(), items: Type.Array(Type.Object({ k: Type.String(), v: Type.Number() })) }))` : ''}
+  .build(({ ctx, params, query, body }, onError) => {
+    ${has('onerror') ? `if (Math.random() < 0) throw onError('${has('errors') && has('details') ? 'E' + i : 'FORBIDDEN'}')
+    if (Math.random() < 0) throw onError('NOT_FOUND')` : ''}
+    return { id: String(params), name: String(body), count: Number(query) || 0, items: [{ k: 'a', v: 1 }] }
+  })`)
+}
+const route = (i: number) => `  .post('/a${i}/:p${i}${i % 3 === 2 ? '/:entityId' : ''}', action${i}.handle, action${i}.docs)`
+const SPLIT = Number(process.env.SPLIT ?? 0)
+if (has('app') && !SPLIT) {
+  lines.push(`\nexport const app = new Elysia().use(problems())`)
+  for (let i = 0; i < N; i++) lines.push(route(i))
+  lines.push(`  .listen(3000)\n`)
+}
+if (has('app') && SPLIT) {
+  const groups = Math.ceil(N / SPLIT)
+  for (let g = 0; g < groups; g++) {
+    lines.push(`\nconst group${g} = new Elysia({ prefix: '/g${g}' }).use(problems())`)
+    for (let i = g * SPLIT; i < Math.min(N, (g + 1) * SPLIT); i++) lines.push(route(i))
+  }
+  lines.push(`\nexport const app = new Elysia().use(problems())`)
+  for (let g = 0; g < groups; g++) lines.push(`  .use(group${g})`)
+  lines.push(`  .listen(3000)\n`)
+}
+await Bun.write(new URL('./consumer.ts', import.meta.url).pathname, lines.join('\n'))

--- a/bench/measure.sh
+++ b/bench/measure.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# usage: [FLAGS=no-x,no-y] [SPLIT=25] ./measure.sh <N>
+bun gen.ts $1 >/dev/null
+../node_modules/.bin/tsc -p tsconfig.json --extendedDiagnostics 2>&1 | grep -E "error TS|Instantiations|Types:|Memory|Check time" | tr -s ' ' | tr '\n' ' '; echo

--- a/bench/tsconfig.json
+++ b/bench/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../tsconfig.json", "compilerOptions": { "noEmit": true, "baseUrl": "..", "paths": {} }, "include": ["./consumer.ts"], "exclude": [] }

--- a/build.ts
+++ b/build.ts
@@ -2,7 +2,7 @@ import type { BuildConfig } from 'bun'
 import dts from 'bun-plugin-dts'
 
 const defaultBuildConfig: BuildConfig = {
-	entrypoints: ['./src/index.ts', './src/action.ts', './src/procedure.ts', './src/error.ts', './src/problems.ts'],
+	entrypoints: ['./src/index.ts', './src/action.ts', './src/procedure.ts'],
 	outdir: './dist',
 	target: 'node',
 	splitting: true,

--- a/build.ts
+++ b/build.ts
@@ -2,7 +2,7 @@ import type { BuildConfig } from 'bun'
 import dts from 'bun-plugin-dts'
 
 const defaultBuildConfig: BuildConfig = {
-	entrypoints: ['./src/index.ts', './src/action.ts', './src/procedure.ts'],
+	entrypoints: ['./src/index.ts', './src/action.ts', './src/procedure.ts', './src/error.ts', './src/problems.ts'],
 	outdir: './dist',
 	target: 'node',
 	splitting: true,

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,12 @@
     "": {
       "name": "@luukgoossen/elysia-procedures",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@sinclair/typebox": "^0.34.33",
         "type-fest": "^4.41.0",
       },
       "devDependencies": {
         "@elysiajs/openapi": "^1.4.15",
-        "@opentelemetry/api": "^1.9.0",
         "@stylistic/eslint-plugin": "^1",
         "@types/bun": "latest",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -20,15 +20,9 @@
         "tstyche": "^3.5.0",
       },
       "peerDependencies": {
-        "@elysiajs/opentelemetry": ">= 1.4.0",
-        "@sentry/bun": ">= 10.19.0",
         "elysia": ">= 1.4.0",
         "typescript": "^5",
       },
-      "optionalPeers": [
-        "@elysiajs/opentelemetry",
-        "@sentry/bun",
-      ],
     },
   },
   "packages": {

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@luukgoossen/elysia-procedures",
@@ -8,6 +9,7 @@
         "type-fest": "^4.41.0",
       },
       "devDependencies": {
+        "@elysiajs/openapi": "^1.4.15",
         "@opentelemetry/api": "^1.9.0",
         "@stylistic/eslint-plugin": "^1",
         "@types/bun": "latest",
@@ -30,6 +32,8 @@
     },
   },
   "packages": {
+    "@elysiajs/openapi": ["@elysiajs/openapi@1.4.15", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-HDtGIrWfFJk6UJS7qbgRmjifbSqnnRGDM3CsU/GVJkxLbEVEkNuQDf+Quh9fGbytSrJ8g4+tX9eVjshYhCH29w=="],
+
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "author": "Luuk Goossen",
   "license": "MIT",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,6 +43,16 @@
       "require": "./dist/procedure.cjs",
       "import": "./dist/procedure.js",
       "types": "./dist/procedure.d.ts"
+    },
+    "./error": {
+      "require": "./dist/error.cjs",
+      "import": "./dist/error.js",
+      "types": "./dist/error.d.ts"
+    },
+    "./problems": {
+      "require": "./dist/problems.cjs",
+      "import": "./dist/problems.js",
+      "types": "./dist/problems.d.ts"
     }
   },
   "scripts": {
@@ -50,6 +60,7 @@
     "test": "bun run eslint . && bun run tsc --noEmit && bun test && bun run tstyche"
   },
   "devDependencies": {
+    "@elysiajs/openapi": "^1.4.15",
     "@opentelemetry/api": "^1.9.0",
     "@stylistic/eslint-plugin": "^1",
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -43,16 +43,6 @@
       "require": "./dist/procedure.cjs",
       "import": "./dist/procedure.js",
       "types": "./dist/procedure.d.ts"
-    },
-    "./error": {
-      "require": "./dist/error.cjs",
-      "import": "./dist/error.js",
-      "types": "./dist/error.d.ts"
-    },
-    "./problems": {
-      "require": "./dist/problems.cjs",
-      "import": "./dist/problems.js",
-      "types": "./dist/problems.d.ts"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@elysiajs/openapi": "^1.4.15",
-    "@opentelemetry/api": "^1.9.0",
     "@stylistic/eslint-plugin": "^1",
     "@types/bun": "latest",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -61,20 +60,11 @@
     "tstyche": "^3.5.0"
   },
   "peerDependencies": {
-    "@elysiajs/opentelemetry": ">= 1.4.0",
-    "@sentry/bun": ">= 10.19.0",
     "typescript": "^5",
     "elysia": ">= 1.4.0"
   },
-  "peerDependenciesMeta": {
-    "@elysiajs/opentelemetry": {
-      "optional": true
-    },
-    "@sentry/bun": {
-      "optional": true
-    }
-  },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@sinclair/typebox": "^0.34.33",
     "type-fest": "^4.41.0"
   },

--- a/src/action.ts
+++ b/src/action.ts
@@ -250,26 +250,17 @@ export class Action<
 		params: Params extends ObjectSchema ? Static<Params> : any
 		query: Query extends ObjectSchema ? Static<Query> : any
 		body: Body extends ObjectSchema ? Static<Body> : any
-	}) => trace({
-		name: this.details?.tracing?.name ?? this.name,
-		op: 'procedure.action',
-		startTime: performance.timeOrigin + performance.now(),
-		attributes: {
-			'procedure.type': 'action',
-			'procedure.name': this.name,
-			...this.details?.tracing?.attributes
-		}
-	}, async span => {
+	}) => trace('action', this.details?.tracing?.name ?? this.name, {
+		'procedure.name': this.name,
+		...this.details?.tracing?.attributes
+	}, () => {
 		const { params, query, body, ...ctx } = context
 
-		const result = await this._execute(ctx, {
+		return this._execute(ctx, {
 			params: params,
 			query: query,
 			body: body,
 		})
-
-		span?.end(performance.timeOrigin + performance.now())
-		return result
 	})
 
 	/**
@@ -282,30 +273,16 @@ export class Action<
 		params: Params extends ObjectSchema ? Static<Params> : any,
 		query: Query extends ObjectSchema ? Static<Query> : any,
 		body: Body extends ObjectSchema ? Static<Body> : any,
-	}): Promise<Out> => trace({
-		name: this.details?.tracing?.name ?? this.name,
-		op: 'procedure.action',
-		startTime: performance.timeOrigin + performance.now(),
-		attributes: {
-			'procedure.type': 'action',
-			'procedure.name': this.name,
-			...this.details?.tracing?.attributes
-		}
-	}, async span => {
+	}): Promise<Out> => trace('action', this.details?.tracing?.name ?? this.name, {
+		'procedure.name': this.name,
+		...this.details?.tracing?.attributes
+	}, async () => {
 		let params = input.params
 		let query = input.query
 		let body = input.body
 
 		// validate the input
-		await trace({
-			name: this.details?.tracing?.name ?? this.name,
-			op: 'procedure.input',
-			startTime: performance.timeOrigin + performance.now(),
-			attributes: {
-				'procedure.type': 'input',
-				'procedure.name': this.name,
-			}
-		}, span => {
+		trace('input', this.details?.tracing?.name ?? this.name, { 'procedure.name': this.name }, () => {
 			// validate the params
 			if (this.params) {
 				params = this.params ? Value.Parse(this.params, input.params) : input.params
@@ -320,8 +297,6 @@ export class Action<
 			if (this.body) {
 				body = this.body ? Value.Parse(this.body, input.body) : input.body
 			}
-
-			span?.end(performance.timeOrigin + performance.now())
 		})
 
 		// run the action
@@ -332,29 +307,10 @@ export class Action<
 		})
 
 		// skip the output validation if no output schema is defined
-		if (!this.output) {
-			span?.end(performance.timeOrigin + performance.now())
-			return result
-		}
+		if (!this.output) return result
 
 		// validate the output
-		const output = await trace({
-			name: this.details?.tracing?.name ?? this.name,
-			op: 'procedure.output',
-			startTime: performance.timeOrigin + performance.now(),
-			attributes: {
-				'procedure.type': 'output',
-				'procedure.name': this.name,
-			}
-		}, span => {
-			const output = Value.Parse(this.output!, result)
-
-			span?.end(performance.timeOrigin + performance.now())
-			return output
-		})
-
-		span?.end(performance.timeOrigin + performance.now())
-		return output
+		return trace('output', this.details?.tracing?.name ?? this.name, { 'procedure.name': this.name }, () => Value.Parse(this.output!, result))
 	}) as Promise<Out>
 
 	private _execute = async (ctx: Context, input: {
@@ -370,25 +326,14 @@ export class Action<
 		}
 
 		// run the action
-		return await trace({
-			name: this.details?.tracing?.name ?? this.name,
-			op: 'procedure.handler',
-			startTime: performance.timeOrigin + performance.now(),
-			attributes: {
-				'procedure.type': 'handler',
-				'procedure.name': this.name,
-				...this.details?.tracing?.attributes
-			}
-		}, async span => {
-			const result = await this._handler({
-				params: input.params,
-				query: input.query,
-				body: input.body,
-				ctx: ctx as Ctx
-			}, this._onError)
-
-			span?.end(performance.timeOrigin + performance.now())
-			return result
-		})
+		return trace('handler', this.details?.tracing?.name ?? this.name, {
+			'procedure.name': this.name,
+			...this.details?.tracing?.attributes
+		}, () => this._handler({
+			params: input.params,
+			query: input.query,
+			body: input.body,
+			ctx: ctx as Ctx
+		}, this._onError))
 	}
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -68,7 +68,7 @@ export type ActionFn<
 
 /**
  * The status-keyed response schemas documented for an action: the output under 200, `ValidationProblem` under 422 and `Problem` per other error status.
- * At runtime the error entries are the model names `'Problem'` / `'ValidationProblem'`, which Elysia resolves from the models the problems() plugin
+ * At runtime the error entries are the model names `'Problem'` / `'ValidationProblem'`, which Elysia resolves from the models the procedures() plugin
  * registers on the root app and which `@elysiajs/openapi` emits as `$ref`s. They are typed as the schemas themselves so routes typecheck on any
  * instance, not only on those whose type carries the models.
  * Error statuses are only typed when the table keeps them literal (inline literals or `defineError`); a widened `number` status documents nothing at the type level.

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,7 +10,7 @@ import type { Promisable, Simplify } from 'type-fest'
 import type { ProcedureFnArgs, AnyMiddleware } from './procedure'
 import type { Context, ObjectSchema, SafeTObject, MergedObject, Decorations } from './utils'
 import type { DocumentDecoration } from 'elysia'
-import type { ErrorFactory, ErrorTable, DefaultErrors, NoErrors } from './error'
+import type { ErrorFactory, ErrorTable, DefaultErrors, NoErrors, Problem, ValidationProblem } from './error'
 
 /**
  * Configuration arguments for creating an action builder.
@@ -68,7 +68,9 @@ export type ActionFn<
 
 /**
  * The status-keyed response schemas documented for an action: the output under 200, `ValidationProblem` under 422 and `Problem` per other error status.
- * Both models are registered by the problems() plugin, which must be mounted on the app.
+ * At runtime the error entries are the model names `'Problem'` / `'ValidationProblem'`, which Elysia resolves from the models the problems() plugin
+ * registers on the root app and which `@elysiajs/openapi` emits as `$ref`s. They are typed as the schemas themselves so routes typecheck on any
+ * instance, not only on those whose type carries the models.
  * Error statuses are only typed when the table keeps them literal (inline literals or `defineError`); a widened `number` status documents nothing at the type level.
  */
 export type ActionResponses<Output extends TSchema | undefined, Errors extends ErrorTable> = Simplify<
@@ -76,7 +78,7 @@ export type ActionResponses<Output extends TSchema | undefined, Errors extends E
 & ErrorResponses<(Errors[keyof Errors] | DefaultErrors[keyof DefaultErrors])['status']>
 >
 
-type ErrorResponses<Status extends number> = number extends Status ? unknown : { [S in Status]: S extends 422 ? 'ValidationProblem' : 'Problem' }
+type ErrorResponses<Status extends number> = number extends Status ? unknown : { [S in Status]: S extends 422 ? typeof ValidationProblem : typeof Problem }
 
 /**
  * Builder class for creating actions with a type-safe API.

--- a/src/action.ts
+++ b/src/action.ts
@@ -5,10 +5,10 @@ import { trace } from './trace'
 import { createErrorFactory, statusesOf } from './error'
 
 // import types
-import type { TSchema, TObject, Static } from '@sinclair/typebox'
+import type { TSchema, Static } from '@sinclair/typebox'
 import type { Promisable, Simplify } from 'type-fest'
 import type { ProcedureFnArgs, AnyMiddleware } from './procedure'
-import type { Context, SafeTObject, MergedObject, Decorations } from './utils'
+import type { Context, ObjectSchema, SafeTObject, MergedObject, Decorations } from './utils'
 import type { DocumentDecoration } from 'elysia'
 import type { ErrorFactory, ErrorTable, DefaultErrors, NoErrors } from './error'
 
@@ -16,9 +16,9 @@ import type { ErrorFactory, ErrorTable, DefaultErrors, NoErrors } from './error'
  * Configuration arguments for creating an action builder.
  */
 export type ActionBuilderArgs<
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Output extends TSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > = {
@@ -43,9 +43,9 @@ export type ActionBuilderArgs<
  */
 export type ActionArgs<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Output extends TSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > = ActionBuilderArgs<Params, Query, Body, Output, Errors> & {
@@ -58,9 +58,9 @@ export type ActionArgs<
  */
 export type ActionFn<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Output extends TSchema | undefined,
 	Out = Output extends TSchema ? Static<Output> : any,
 	Errors extends ErrorTable = NoErrors
@@ -84,9 +84,9 @@ type ErrorResponses<Status extends number> = number extends Status ? unknown : {
  */
 export class ActionBuilder<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Output extends TSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > {
@@ -103,9 +103,9 @@ export class ActionBuilder<
 	 * @private
 	 */
 	private _apply = <
-		P extends TObject | undefined,
-		Q extends TObject | undefined,
-		B extends TObject | undefined,
+		P extends ObjectSchema | undefined,
+		Q extends ObjectSchema | undefined,
+		B extends ObjectSchema | undefined,
 		O extends TSchema | undefined
 	>(
 		changes: Partial<ActionBuilderArgs<P, Q, B, O, Errors>>
@@ -120,7 +120,7 @@ export class ActionBuilder<
 	 * Adds or merges route parameter definitions to the action.
 	 * @param params - The TypeBox schema defining the route parameters
 	 */
-	public params = <T extends TObject>(params: SafeTObject<T, Params>) => {
+	public params = <T extends ObjectSchema>(params: SafeTObject<T, Params>) => {
 		const mergedParams = merge(this._state.params, params)
 		return this._apply<MergedObject<SafeTObject<T, Params>, Params>, Query, Body, Output>({
 			params: mergedParams
@@ -131,7 +131,7 @@ export class ActionBuilder<
 	 * Adds or merges query parameter definitions to the action.
 	 * @param query - The TypeBox schema defining the query parameters
 	 */
-	public query = <T extends TObject>(query: SafeTObject<T, Query>) => {
+	public query = <T extends ObjectSchema>(query: SafeTObject<T, Query>) => {
 		const mergedQuery = merge(this._state.query, query)
 		return this._apply<Params, MergedObject<SafeTObject<T, Query>, Query>, Body, Output>({
 			query: mergedQuery
@@ -142,7 +142,7 @@ export class ActionBuilder<
 	 * Adds or merges request body definitions to the action.
 	 * @param body - The TypeBox schema defining the request body
 	 */
-	public body = <T extends TObject>(body: SafeTObject<T, Body>) => {
+	public body = <T extends ObjectSchema>(body: SafeTObject<T, Body>) => {
 		const mergedBody = merge(this._state.body, body)
 		return this._apply<Params, Query, MergedObject<SafeTObject<T, Body>, Body>, Output>({
 			body: mergedBody
@@ -176,9 +176,9 @@ export class ActionBuilder<
  */
 export class Action<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Output extends TSchema | undefined,
 	Out,
 	Errors extends ErrorTable = NoErrors
@@ -245,9 +245,9 @@ export class Action<
 	 * @returns
 	 */
 	public handle = async (context: Context & {
-		params: Params extends TObject ? Static<Params> : any
-		query: Query extends TObject ? Static<Query> : any
-		body: Body extends TObject ? Static<Body> : any
+		params: Params extends ObjectSchema ? Static<Params> : any
+		query: Query extends ObjectSchema ? Static<Query> : any
+		body: Body extends ObjectSchema ? Static<Body> : any
 	}) => trace({
 		name: this.details?.tracing?.name ?? this.name,
 		op: 'procedure.action',
@@ -277,9 +277,9 @@ export class Action<
 	 * @returns
 	 */
 	public run = async (ctx: Context, input: {
-		params: Params extends TObject ? Static<Params> : any,
-		query: Query extends TObject ? Static<Query> : any,
-		body: Body extends TObject ? Static<Body> : any,
+		params: Params extends ObjectSchema ? Static<Params> : any,
+		query: Query extends ObjectSchema ? Static<Query> : any,
+		body: Body extends ObjectSchema ? Static<Body> : any,
 	}): Promise<Out> => trace({
 		name: this.details?.tracing?.name ?? this.name,
 		op: 'procedure.action',
@@ -356,9 +356,9 @@ export class Action<
 	}) as Promise<Out>
 
 	private _execute = async (ctx: Context, input: {
-		params: Params extends TObject ? Static<Params> : any,
-		query: Query extends TObject ? Static<Query> : any,
-		body: Body extends TObject ? Static<Body> : any,
+		params: Params extends ObjectSchema ? Static<Params> : any,
+		query: Query extends ObjectSchema ? Static<Query> : any,
+		body: Body extends ObjectSchema ? Static<Body> : any,
 	}): Promise<Out> => {
 
 		// run the middlewares

--- a/src/action.ts
+++ b/src/action.ts
@@ -34,7 +34,7 @@ export type ActionBuilderArgs<
 	middlewares: AnyMiddleware[]
 	/** Name of the action for identification */
 	name: string
-	/** API documentation details for the action, carrying the effective error configuration */
+	/** API documentation details for the action, including the effective error configuration */
 	details?: Decorations<Errors>
 }
 
@@ -67,11 +67,15 @@ export type ActionFn<
 > = (input: ProcedureFnArgs<Ctx, Params, Query, Body>, onError: ErrorFactory<Errors>) => Promisable<Out>
 
 /**
- * The status-keyed response schemas documented for an action: the output under 200, `ValidationProblem` under 422 and `Problem` per other error status.
- * At runtime the error entries are the model names `'Problem'` / `'ValidationProblem'`, which Elysia resolves from the models the procedures() plugin
- * registers on the root app and which `@elysiajs/openapi` emits as `$ref`s. They are typed as the schemas themselves so routes typecheck on any
- * instance, not only on those whose type carries the models.
- * Error statuses are only typed when the table keeps them literal (inline literals or `defineError`); a widened `number` status documents nothing at the type level.
+ * The response schemas an action documents, keyed by status: the output under 200, `ValidationProblem` under 422
+ * and `Problem` under every other status in the error table.
+ *
+ * At runtime the error entries are the model names `'Problem'` and `'ValidationProblem'`. Elysia resolves those from
+ * the models the procedures() plugin registers on the root app, and `@elysiajs/openapi` emits them as `$ref`s. The
+ * type uses the schemas themselves, so routes typecheck on any instance, not only on one whose type carries the models.
+ *
+ * Error statuses only show up in the type when the table keeps them literal (inline literals or `defineError`).
+ * A status widened to `number` documents nothing.
  */
 export type ActionResponses<Output extends TSchema | undefined, Errors extends ErrorTable> = Simplify<
 (Output extends TSchema ? { 200: Output } : unknown)
@@ -191,7 +195,7 @@ export class Action<
 
 	/** Name of the action for identification */
 	name: string
-	/** API documentation details for the action, carrying the effective error configuration */
+	/** API documentation details for the action, including the effective error configuration */
 	details?: Decorations<Errors>
 	/** TypeBox schema for route parameters */
 	params: Params

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,12 +2,15 @@
 import { Value } from '@sinclair/typebox/value'
 import { merge, toCamelCase } from './utils'
 import { trace } from './trace'
+import { createErrorFactory, statusesOf } from './error'
 
 // import types
 import type { TSchema, TObject, Static } from '@sinclair/typebox'
-import type { Promisable } from 'type-fest'
+import type { Promisable, Simplify } from 'type-fest'
 import type { ProcedureFnArgs, AnyMiddleware } from './procedure'
 import type { Context, SafeTObject, MergedObject, Decorations } from './utils'
+import type { DocumentDecoration } from 'elysia'
+import type { ErrorFactory, ErrorTable, DefaultErrors, NoErrors } from './error'
 
 /**
  * Configuration arguments for creating an action builder.
@@ -16,7 +19,8 @@ export type ActionBuilderArgs<
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
-	Output extends TSchema | undefined
+	Output extends TSchema | undefined,
+	Errors extends ErrorTable = NoErrors
 > = {
 	/** TypeBox schema for route parameters */
 	params: Params
@@ -30,8 +34,8 @@ export type ActionBuilderArgs<
 	middlewares: AnyMiddleware[]
 	/** Name of the action for identification */
 	name: string
-	/** API documentation details for the action */
-	details?: Decorations
+	/** API documentation details for the action, carrying the effective error configuration */
+	details?: Decorations<Errors>
 }
 
 /**
@@ -42,10 +46,11 @@ export type ActionArgs<
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
-	Output extends TSchema | undefined
-> = ActionBuilderArgs<Params, Query, Body, Output> & {
+	Output extends TSchema | undefined,
+	Errors extends ErrorTable = NoErrors
+> = ActionBuilderArgs<Params, Query, Body, Output, Errors> & {
 	/** The main handler function of the action */
-	handler: ActionFn<Ctx, Params, Query, Body, Output>
+	handler: ActionFn<Ctx, Params, Query, Body, Output, any, Errors>
 }
 
 /**
@@ -57,8 +62,21 @@ export type ActionFn<
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
 	Output extends TSchema | undefined,
-	Out = Output extends TSchema ? Static<Output> : any
-> = (input: ProcedureFnArgs<Ctx, Params, Query, Body>) => Promisable<Out>
+	Out = Output extends TSchema ? Static<Output> : any,
+	Errors extends ErrorTable = NoErrors
+> = (input: ProcedureFnArgs<Ctx, Params, Query, Body>, onError: ErrorFactory<Errors>) => Promisable<Out>
+
+/**
+ * The status-keyed response schemas documented for an action: the output under 200, `ValidationProblem` under 422 and `Problem` per other error status.
+ * Both models are registered by the problems() plugin, which must be mounted on the app.
+ * Error statuses are only typed when the table keeps them literal (inline literals or `defineError`); a widened `number` status documents nothing at the type level.
+ */
+export type ActionResponses<Output extends TSchema | undefined, Errors extends ErrorTable> = Simplify<
+(Output extends TSchema ? { 200: Output } : unknown)
+& ErrorResponses<(Errors[keyof Errors] | DefaultErrors[keyof DefaultErrors])['status']>
+>
+
+type ErrorResponses<Status extends number> = number extends Status ? unknown : { [S in Status]: S extends 422 ? 'ValidationProblem' : 'Problem' }
 
 /**
  * Builder class for creating actions with a type-safe API.
@@ -70,10 +88,11 @@ export class ActionBuilder<
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
 	Output extends TSchema | undefined,
+	Errors extends ErrorTable = NoErrors
 > {
-	private _state: ActionBuilderArgs<Params, Query, Body, Output>
+	private _state: ActionBuilderArgs<Params, Query, Body, Output, Errors>
 
-	constructor(base: ActionBuilderArgs<Params, Query, Body, Output>) {
+	constructor(base: ActionBuilderArgs<Params, Query, Body, Output, Errors>) {
 		this._state = base
 	}
 
@@ -89,12 +108,12 @@ export class ActionBuilder<
 		B extends TObject | undefined,
 		O extends TSchema | undefined
 	>(
-		changes: Partial<ActionBuilderArgs<P, Q, B, O>>
-	): ActionBuilder<Ctx, P, Q, B, O> => {
-		return new ActionBuilder<Ctx, P, Q, B, O>({
+		changes: Partial<ActionBuilderArgs<P, Q, B, O, Errors>>
+	): ActionBuilder<Ctx, P, Q, B, O, Errors> => {
+		return new ActionBuilder<Ctx, P, Q, B, O, Errors>({
 			...this._state,
 			...changes
-		} as ActionBuilderArgs<P, Q, B, O>)
+		} as ActionBuilderArgs<P, Q, B, O, Errors>)
 	}
 
 	/**
@@ -143,8 +162,8 @@ export class ActionBuilder<
 	 * @param handler - The function to execute when this action is called
 	 * @returns A built action with the given handler
 	 */
-	public build = <Out>(handler: ActionFn<Ctx, Params, Query, Body, Output, Output extends TSchema ? Static<Output> : Out>) => {
-		return new Action<Ctx, Params, Query, Body, Output, Output extends TSchema ? Static<Output> : Out>({
+	public build = <Out>(handler: ActionFn<Ctx, Params, Query, Body, Output, Output extends TSchema ? Static<Output> : Out, Errors>) => {
+		return new Action<Ctx, Params, Query, Body, Output, Output extends TSchema ? Static<Output> : Out, Errors>({
 			handler: handler as any,
 			...this._state
 		})
@@ -162,14 +181,16 @@ export class Action<
 	Body extends TObject | undefined,
 	Output extends TSchema | undefined,
 	Out,
+	Errors extends ErrorTable = NoErrors
 > {
-	private _handler: ActionFn<Ctx, Params, Query, Body, Output>
+	private _handler: ActionFn<Ctx, Params, Query, Body, Output, any, Errors>
 	private _middlewares: AnyMiddleware[]
+	private _onError: ErrorFactory<Errors>
 
 	/** Name of the action for identification */
 	name: string
-	/** API documentation details for the action */
-	details?: Decorations
+	/** API documentation details for the action, carrying the effective error configuration */
+	details?: Decorations<Errors>
 	/** TypeBox schema for route parameters */
 	params: Params
 	/** TypeBox schema for query parameters */
@@ -179,9 +200,10 @@ export class Action<
 	/** TypeBox schema for response output */
 	output: Output
 
-	constructor(input: ActionArgs<Ctx, Params, Query, Body, Output>) {
+	constructor(input: ActionArgs<Ctx, Params, Query, Body, Output, Errors>) {
 		this._handler = input.handler
 		this._middlewares = input.middlewares
+		this._onError = createErrorFactory(input.details?.errors)
 
 		this.name = input.name
 		this.details = input.details
@@ -195,15 +217,21 @@ export class Action<
 	 * The API documentation for the action in Elysia route handler format.
 	 */
 	public get docs() {
+		const details = Object.fromEntries(Object.entries(this.details ?? {}).filter(([key]) => key !== 'errors' && key !== 'tracing')) as DocumentDecoration
+		const statuses = statusesOf(this.details?.errors?.table ?? {})
+
 		return {
 			params: this.params as any,
 			query: this.query,
 			body: this.body,
-			response: this.output,
+			response: {
+				...(this.output ? { 200: this.output } : {}),
+				...Object.fromEntries(statuses.map(status => [status, status === 422 ? 'ValidationProblem' : 'Problem'])),
+			} as ActionResponses<Output, Errors>,
 			detail: {
 				summary: this.name,
 				operationId: toCamelCase(this.name),
-				...this.details
+				...details,
 			},
 		}
 	}
@@ -355,7 +383,7 @@ export class Action<
 				query: input.query,
 				body: input.body,
 				ctx: ctx as Ctx
-			})
+			}, this._onError)
 
 			span?.end(performance.timeOrigin + performance.now())
 			return result

--- a/src/action.ts
+++ b/src/action.ts
@@ -274,9 +274,9 @@ export class Action<
 	 * @returns
 	 */
 	public run = async (ctx: Context, input: {
-		params: Params extends ObjectSchema ? Static<Params> : any,
-		query: Query extends ObjectSchema ? Static<Query> : any,
-		body: Body extends ObjectSchema ? Static<Body> : any,
+		params: Params extends ObjectSchema ? Static<Params> : any
+		query: Query extends ObjectSchema ? Static<Query> : any
+		body: Body extends ObjectSchema ? Static<Body> : any
 	}): Promise<Out> => trace('action', this.details?.tracing?.name ?? this.name, {
 		'procedure.name': this.name,
 		...this.details?.tracing?.attributes
@@ -318,9 +318,9 @@ export class Action<
 	}) as Promise<Out>
 
 	private _execute = async (ctx: Context, input: {
-		params: Params extends ObjectSchema ? Static<Params> : any,
-		query: Query extends ObjectSchema ? Static<Query> : any,
-		body: Body extends ObjectSchema ? Static<Body> : any,
+		params: Params extends ObjectSchema ? Static<Params> : any
+		query: Query extends ObjectSchema ? Static<Query> : any
+		body: Body extends ObjectSchema ? Static<Body> : any
 	}): Promise<Out> => {
 
 		// run the middlewares

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,17 +12,17 @@ import type { Simplify } from 'type-fest'
  */
 export type ErrorEntry<M extends ObjectSchema | undefined = undefined> = {
 	/** HTTP status code of the error */
-	status: number;
+	status: number
 	/** TypeBox schema for the metadata argument of onError(); without it the error takes no metadata */
-	metadata?: M;
+	metadata?: M
 	/** Default title, as a string or a function of the validated metadata */
 	title?:
 	| string
-	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
+	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string)
 	/** Default detail, same shape as title */
 	detail?:
 	| string
-	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
+	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string)
 }
 
 /**
@@ -40,9 +40,9 @@ export type NoErrors = Record<never, never>
  */
 export type ErrorConfig<Errors extends ErrorTable = ErrorTable> = {
 	/** Builds the RFC 9457 `type` URI for a reason; defaults to 'about:blank' for every reason */
-	type?: (reason: string) => string;
+	type?: (reason: string) => string
 	/** Error table, merged by key with the parent's; the child's entry wins */
-	table?: Errors;
+	table?: Errors
 }
 
 /**
@@ -79,10 +79,7 @@ export type ProblemFieldLocation = Static<typeof ProblemFieldLocation>
  */
 export const ProblemFieldError = Type.Object({
 	in: ProblemFieldLocation,
-	pointer: Type.String({
-		description:
-      'JSON pointer fragment to the invalid value within its location, e.g. #/tags/1',
-	}),
+	pointer: Type.String({ description: 'JSON pointer fragment to the invalid value within its location, e.g. #/tags/1' }),
 	detail: Type.String(),
 	received: Type.Optional(Type.String({ description: 'JSON of the received value; omitted for sensitive fields, truncated when long' })),
 })
@@ -90,29 +87,14 @@ export const ProblemFieldError = Type.Object({
 export type ProblemFieldError = Static<typeof ProblemFieldError>
 
 const problemProperties = {
-	type: Type.String({
-		description: 'URI reference identifying the problem type',
-	}),
-	title: Type.String({
-		description: 'Short, human-readable summary of the problem type',
-	}),
+	type: Type.String({ description: 'URI reference identifying the problem type' }),
+	title: Type.String({ description: 'Short, human-readable summary of the problem type' }),
 	status: Type.Integer({ minimum: 100, maximum: 599 }),
-	detail: Type.Optional(
-		Type.String({
-			description: 'Human-readable explanation specific to this occurrence',
-		}),
-	),
-	instance: Type.Optional(
-		Type.String({ description: 'Request path that produced the problem' }),
-	),
+	detail: Type.Optional(Type.String({ description: 'Human-readable explanation specific to this occurrence' })),
+	instance: Type.Optional(Type.String({ description: 'Request path that produced the problem' })),
 	reason: Type.String({ description: 'Stable UPPER_SNAKE error code' }),
 	metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
-	reference: Type.Optional(
-		Type.String({
-			description:
-        'Error tracking reference, present when the error was reported',
-		}),
-	),
+	reference: Type.Optional(Type.String({ description: 'Error tracking reference, present when the error was reported' })),
 }
 
 /**
@@ -125,13 +107,10 @@ export type Problem = Static<typeof Problem>
 /**
  * A 422 problem carrying one entry per invalid field.
  */
-export const ValidationProblem = Type.Object(
-	{
-		...problemProperties,
-		errors: Type.Array(ProblemFieldError),
-	},
-	{ $id: 'ValidationProblem' },
-)
+export const ValidationProblem = Type.Object({
+	...problemProperties,
+	errors: Type.Array(ProblemFieldError),
+}, { $id: 'ValidationProblem' })
 
 export type ValidationProblem = Static<typeof ValidationProblem>
 
@@ -139,26 +118,30 @@ export type ValidationProblem = Static<typeof ValidationProblem>
  * Extension members that can be merged into a problem at serialization time.
  */
 export type ProblemExtra = {
-	instance?: string;
-	reference?: string;
+	instance?: string
+	reference?: string
 }
 
 /**
  * Options accepted by the onError factory for a single occurrence.
  */
 export type ApiErrorOptions = {
-	title?: string;
-	detail?: string;
-	cause?: unknown;
+	title?: string
+	detail?: string
+	cause?: unknown
 }
+
+/**
+ * Brand marking ApiErrors. Created with Symbol.for so every copy of this package, e.g. the CJS build loaded next to
+ * the ESM build, shares it; an `instanceof` check would fail across copies and turn a typed error into a 500.
+ */
+const API_ERROR: unique symbol = Symbol.for('elysia-procedures.ApiError')
 
 /**
  * An error thrown by a handler. The procedures() plugin serializes it to an RFC 9457 problem.
  */
-export class ApiError<
-	Reason extends string = string,
-	Meta = unknown,
-> extends Error {
+export class ApiError<Reason extends string = string, Meta = unknown> extends Error {
+	readonly [API_ERROR] = true
 	readonly status: number
 	readonly reason: Reason
 	readonly metadata: Meta
@@ -167,18 +150,15 @@ export class ApiError<
 	readonly type: string
 
 	constructor(input: {
-		status: number;
-		reason: Reason;
-		metadata: Meta;
-		title: string;
-		detail?: string;
-		type: string;
-		cause?: unknown;
+		status: number
+		reason: Reason
+		metadata: Meta
+		title: string
+		detail?: string
+		type: string
+		cause?: unknown
 	}) {
-		super(
-			input.title,
-			input.cause === undefined ? undefined : { cause: input.cause },
-		)
+		super(input.title, input.cause === undefined ? undefined : { cause: input.cause })
 		this.name = 'ApiError'
 		this.status = input.status
 		this.reason = input.reason
@@ -189,9 +169,18 @@ export class ApiError<
 	}
 
 	/**
-   * Serializes the error to an RFC 9457 problem. The cause is never included.
-   * @param extra - Extension members (instance, reference) to merge
-   */
+	 * Whether the value is an ApiError. Prefer this over `instanceof`: it also holds for errors created by another
+	 * copy of this package.
+	 * @param value - The value to check
+	 */
+	static is(value: unknown): value is ApiError {
+		return typeof value === 'object' && value !== null && (value as Record<symbol, unknown>)[API_ERROR] === true
+	}
+
+	/**
+	 * Serializes the error to an RFC 9457 problem. The cause is never included.
+	 * @param extra - Extension members (instance, reference) to merge
+	 */
 	public toProblem = (extra: ProblemExtra = {}): Problem => {
 		const problem: Problem = {
 			type: this.type,
@@ -213,8 +202,7 @@ export class ApiError<
 /**
  * Metadata type of an error table entry.
  */
-export type ErrorMetadata<E extends ErrorEntry<any>> =
-  E['metadata'] extends ObjectSchema ? Static<E['metadata']> : undefined
+export type ErrorMetadata<E extends ErrorEntry<any>> = E['metadata'] extends ObjectSchema ? Static<E['metadata']> : undefined
 
 /**
  * Arguments of the onError factory after the reason: metadata is required if the entry has a schema.
@@ -232,12 +220,12 @@ export type ErrorFactory<Errors extends ErrorTable> = {
 	<R extends keyof MergedErrors<DefaultErrors, Errors> & string>(
 		reason: R,
 		...args: ErrorArgs<MergedErrors<DefaultErrors, Errors>[R]>
-	): ApiError<R, ErrorMetadata<MergedErrors<DefaultErrors, Errors>[R]>>;
+	): ApiError<R, ErrorMetadata<MergedErrors<DefaultErrors, Errors>[R]>>
 	/** Wraps an unexpected failure in a 5xx error. The cause reaches the reporter and the log, never the response */
 	unexpected(
 		cause: unknown,
 		options?: ApiErrorOptions & { reason?: keyof Errors & string },
-	): ApiError<string, undefined>;
+	): ApiError<string, undefined>
 }
 
 /** Converts UPPER_SNAKE to Title Case */
@@ -291,10 +279,7 @@ export const createErrorFactory = <Errors extends ErrorTable>(
 			status: entry.status,
 			reason,
 			metadata,
-			title:
-        options.title ??
-        resolveCopy(entry.title, metadata) ??
-        toTitleCase(reason),
+			title: options.title ?? resolveCopy(entry.title, metadata) ?? toTitleCase(reason),
 			detail: options.detail ?? resolveCopy(entry.detail, metadata),
 			type: typeOf(reason),
 			cause: options.cause,
@@ -367,26 +352,26 @@ export const statusesOf = (table: ErrorTable): number[] =>
  * @param entry - The error entry
  */
 export function defineError<const S extends number, M extends ObjectSchema>(entry: {
-	status: S;
-	metadata: M;
-	title?: string | ((metadata: Static<M>) => string);
-	detail?: string | ((metadata: Static<M>) => string);
+	status: S
+	metadata: M
+	title?: string | ((metadata: Static<M>) => string)
+	detail?: string | ((metadata: Static<M>) => string)
 }): {
-	status: S;
-	metadata: M;
-	title?: string | ((metadata: Static<M>) => string);
-	detail?: string | ((metadata: Static<M>) => string);
+	status: S
+	metadata: M
+	title?: string | ((metadata: Static<M>) => string)
+	detail?: string | ((metadata: Static<M>) => string)
 }
 export function defineError<const S extends number>(entry: {
-	status: S;
-	metadata?: undefined;
-	title?: string | (() => string);
-	detail?: string | (() => string);
+	status: S
+	metadata?: undefined
+	title?: string | (() => string)
+	detail?: string | (() => string)
 }): {
-	status: S;
-	metadata?: undefined;
-	title?: string | (() => string);
-	detail?: string | (() => string);
+	status: S
+	metadata?: undefined
+	title?: string | (() => string)
+	detail?: string | (() => string)
 }
 export function defineError(entry: ErrorEntry<any>) {
 	return entry

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,13 +3,14 @@ import { Type } from '@sinclair/typebox'
 import { Value } from '@sinclair/typebox/value'
 
 // import types
-import type { Static, TObject } from '@sinclair/typebox'
+import type { Static } from '@sinclair/typebox'
+import type { ObjectSchema } from './utils'
 import type { Simplify } from 'type-fest'
 
 /**
  * A single entry in an error table.
  */
-export type ErrorEntry<M extends TObject | undefined = undefined> = {
+export type ErrorEntry<M extends ObjectSchema | undefined = undefined> = {
 	/** HTTP status code of the error */
 	status: number;
 	/** TypeBox schema for the metadata argument of onError(); omit = no metadata */
@@ -17,11 +18,11 @@ export type ErrorEntry<M extends TObject | undefined = undefined> = {
 	/** Default title; string or function of the (validated) metadata */
 	title?:
 	| string
-	| ((metadata: M extends TObject ? Static<M> : undefined) => string);
+	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
 	/** Default detail; same shape as title */
 	detail?:
 	| string
-	| ((metadata: M extends TObject ? Static<M> : undefined) => string);
+	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
 }
 
 /**
@@ -213,39 +214,24 @@ export class ApiError<
  * Metadata type of an error table entry.
  */
 export type ErrorMetadata<E extends ErrorEntry<any>> =
-  E['metadata'] extends TObject ? Static<E['metadata']> : undefined
+  E['metadata'] extends ObjectSchema ? Static<E['metadata']> : undefined
 
 /**
  * Arguments of the onError factory after the reason: metadata is required if the entry has a schema.
  */
-export type ErrorArgs<E extends ErrorEntry<any>> = E['metadata'] extends TObject
+export type ErrorArgs<E extends ErrorEntry<any>> = E['metadata'] extends ObjectSchema
 	? [metadata: Static<E['metadata']>, options?: ApiErrorOptions]
 	: [metadata?: undefined, options?: ApiErrorOptions]
 
-type UnionToIntersection<U> = (
-	U extends unknown ? (k: U) => void : never
-) extends (k: infer I) => void
-	? I
-	: never
-
-/**
- * One call signature per reason; intersected they behave as overloads, keeping each metadata type concrete.
- */
-export type ErrorSignatures<Errors extends ErrorTable> = UnionToIntersection<
-{
-	[R in keyof Errors & string]: (
-		reason: R,
-		...args: ErrorArgs<Errors[R]>
-	) => ApiError<R, ErrorMetadata<Errors[R]>>;
-}[keyof Errors & string]
->
-
 /**
  * Factory producing typed ApiErrors from an error table. The package defaults are always callable, overridable by key.
+ * A single generic signature resolves the metadata type per call site, so the table is never expanded eagerly.
  */
-export type ErrorFactory<Errors extends ErrorTable> = ErrorSignatures<
-MergedErrors<DefaultErrors, Errors>
-> & {
+export type ErrorFactory<Errors extends ErrorTable> = {
+	<R extends keyof MergedErrors<DefaultErrors, Errors> & string>(
+		reason: R,
+		...args: ErrorArgs<MergedErrors<DefaultErrors, Errors>[R]>
+	): ApiError<R, ErrorMetadata<MergedErrors<DefaultErrors, Errors>[R]>>;
 	/** Wraps an unexpected failure as a 5xx error; the cause is reported but never serialized */
 	unexpected(
 		cause: unknown,
@@ -378,7 +364,7 @@ export const statusesOf = (table: ErrorTable): number[] =>
  * so they can be written inline without annotating the metadata parameter.
  * @param entry - The error entry
  */
-export function defineError<const S extends number, M extends TObject>(entry: {
+export function defineError<const S extends number, M extends ObjectSchema>(entry: {
 	status: S;
 	metadata: M;
 	title?: string | ((metadata: Static<M>) => string);

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,13 +13,13 @@ import type { Simplify } from 'type-fest'
 export type ErrorEntry<M extends ObjectSchema | undefined = undefined> = {
 	/** HTTP status code of the error */
 	status: number;
-	/** TypeBox schema for the metadata argument of onError(); omit = no metadata */
+	/** TypeBox schema for the metadata argument of onError(); without it the error takes no metadata */
 	metadata?: M;
-	/** Default title; string or function of the (validated) metadata */
+	/** Default title, as a string or a function of the validated metadata */
 	title?:
 	| string
 	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
-	/** Default detail; same shape as title */
+	/** Default detail, same shape as title */
 	detail?:
 	| string
 	| ((metadata: M extends ObjectSchema ? Static<M> : undefined) => string);
@@ -39,14 +39,14 @@ export type NoErrors = Record<never, never>
  * Error configuration of a procedure or action.
  */
 export type ErrorConfig<Errors extends ErrorTable = ErrorTable> = {
-	/** Builds the RFC 9457 `type` URI for a reason; default: () => 'about:blank' */
+	/** Builds the RFC 9457 `type` URI for a reason; defaults to 'about:blank' for every reason */
 	type?: (reason: string) => string;
-	/** Error table; merged by key with the parent's, child wins */
+	/** Error table, merged by key with the parent's; the child's entry wins */
 	table?: Errors;
 }
 
 /**
- * Error entries the package relies on. Always present, overridable by key.
+ * Error entries the package itself uses. They are always present in every table and can be overridden by key.
  */
 export const DEFAULT_ERRORS = {
 	INTERNAL: {
@@ -153,7 +153,7 @@ export type ApiErrorOptions = {
 }
 
 /**
- * A thrown API error. Serialized to an RFC 9457 problem by the procedures() plugin.
+ * An error thrown by a handler. The procedures() plugin serializes it to an RFC 9457 problem.
  */
 export class ApiError<
 	Reason extends string = string,
@@ -224,15 +224,16 @@ export type ErrorArgs<E extends ErrorEntry<any>> = E['metadata'] extends ObjectS
 	: [metadata?: undefined, options?: ApiErrorOptions]
 
 /**
- * Factory producing typed ApiErrors from an error table. The package defaults are always callable, overridable by key.
- * A single generic signature resolves the metadata type per call site, so the table is never expanded eagerly.
+ * Creates typed ApiErrors from an error table. The package defaults are always callable and can be overridden by key.
+ * One generic signature resolves the metadata type per call site instead of one overload per entry, which keeps
+ * the type checker's work small for large tables.
  */
 export type ErrorFactory<Errors extends ErrorTable> = {
 	<R extends keyof MergedErrors<DefaultErrors, Errors> & string>(
 		reason: R,
 		...args: ErrorArgs<MergedErrors<DefaultErrors, Errors>[R]>
 	): ApiError<R, ErrorMetadata<MergedErrors<DefaultErrors, Errors>[R]>>;
-	/** Wraps an unexpected failure as a 5xx error; the cause is reported but never serialized */
+	/** Wraps an unexpected failure in a 5xx error. The cause reaches the reporter and the log, never the response */
 	unexpected(
 		cause: unknown,
 		options?: ApiErrorOptions & { reason?: keyof Errors & string },
@@ -252,7 +253,8 @@ const resolveCopy = (copy: ErrorEntry<any>['title'], metadata: unknown) =>
 	typeof copy === 'function' ? copy(metadata as any) : copy
 
 /**
- * Creates an onError factory bound to an effective error configuration. The package defaults back any missing entry.
+ * Creates an onError factory bound to an effective error configuration. Entries missing from the table fall back
+ * to the package defaults.
  * @param config - The effective error configuration; `type` defaults to 'about:blank'
  */
 export const createErrorFactory = <Errors extends ErrorTable>(
@@ -324,7 +326,7 @@ export const createErrorFactory = <Errors extends ErrorTable>(
 }
 
 /**
- * Merges two error configurations. The child's table entries and type function win.
+ * Merges two error configurations. The child's table entries win per key, and so does its `type` function when set.
  */
 export const mergeErrors = <
 	Parent extends ErrorTable,
@@ -360,8 +362,8 @@ export const statusesOf = (table: ErrorTable): number[] =>
 	].sort((a, b) => a - b)
 
 /**
- * Identity helper that types the `title` / `detail` functions of an entry from its `metadata` schema,
- * so they can be written inline without annotating the metadata parameter.
+ * Returns the entry unchanged, but typed so that the `title` and `detail` functions receive the metadata type of
+ * the entry's own schema. Inside a plain object literal that parameter would have to be annotated by hand.
  * @param entry - The error entry
  */
 export function defineError<const S extends number, M extends ObjectSchema>(entry: {

--- a/src/error.ts
+++ b/src/error.ts
@@ -153,7 +153,7 @@ export type ApiErrorOptions = {
 }
 
 /**
- * A thrown API error. Serialized to an RFC 9457 problem by the problems() plugin.
+ * A thrown API error. Serialized to an RFC 9457 problem by the procedures() plugin.
  */
 export class ApiError<
 	Reason extends string = string,

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,405 @@
+// import dependencies
+import { Type } from '@sinclair/typebox'
+import { Value } from '@sinclair/typebox/value'
+
+// import types
+import type { Static, TObject } from '@sinclair/typebox'
+import type { Simplify } from 'type-fest'
+
+/**
+ * A single entry in an error table.
+ */
+export type ErrorEntry<M extends TObject | undefined = undefined> = {
+	/** HTTP status code of the error */
+	status: number;
+	/** TypeBox schema for the metadata argument of onError(); omit = no metadata */
+	metadata?: M;
+	/** Default title; string or function of the (validated) metadata */
+	title?:
+	| string
+	| ((metadata: M extends TObject ? Static<M> : undefined) => string);
+	/** Default detail; same shape as title */
+	detail?:
+	| string
+	| ((metadata: M extends TObject ? Static<M> : undefined) => string);
+}
+
+/**
+ * A table of errors keyed by their stable reason.
+ */
+export type ErrorTable = Record<string, ErrorEntry<any>>
+
+/**
+ * An empty error table.
+ */
+export type NoErrors = Record<never, never>
+
+/**
+ * Error configuration of a procedure or action.
+ */
+export type ErrorConfig<Errors extends ErrorTable = ErrorTable> = {
+	/** Builds the RFC 9457 `type` URI for a reason; default: () => 'about:blank' */
+	type?: (reason: string) => string;
+	/** Error table; merged by key with the parent's, child wins */
+	table?: Errors;
+}
+
+/**
+ * Error entries the package relies on. Always present, overridable by key.
+ */
+export const DEFAULT_ERRORS = {
+	INTERNAL: {
+		status: 500,
+		title: 'Something went wrong',
+		detail: 'Please try again later. If the problem persists, contact support.',
+	},
+	INVALID_INPUT: { status: 422, title: 'Invalid input' },
+	MALFORMED_REQUEST: { status: 400, title: 'Malformed request' },
+	NOT_FOUND: { status: 404, title: 'Not found' },
+} as const satisfies ErrorTable
+
+export type DefaultErrors = typeof DEFAULT_ERRORS
+
+/**
+ * Where a request value lives, using the OpenAPI parameter vocabulary plus `body`.
+ */
+export const ProblemFieldLocation = Type.Union([
+	Type.Literal('body'),
+	Type.Literal('path'),
+	Type.Literal('query'),
+	Type.Literal('header'),
+	Type.Literal('cookie'),
+])
+
+export type ProblemFieldLocation = Static<typeof ProblemFieldLocation>
+
+/**
+ * A single field error within a validation problem.
+ */
+export const ProblemFieldError = Type.Object({
+	in: ProblemFieldLocation,
+	pointer: Type.String({
+		description:
+      'JSON pointer fragment to the invalid value within its location, e.g. #/tags/1',
+	}),
+	detail: Type.String(),
+	received: Type.Optional(Type.String({ description: 'JSON of the received value; omitted for sensitive fields, truncated when long' })),
+})
+
+export type ProblemFieldError = Static<typeof ProblemFieldError>
+
+const problemProperties = {
+	type: Type.String({
+		description: 'URI reference identifying the problem type',
+	}),
+	title: Type.String({
+		description: 'Short, human-readable summary of the problem type',
+	}),
+	status: Type.Integer({ minimum: 100, maximum: 599 }),
+	detail: Type.Optional(
+		Type.String({
+			description: 'Human-readable explanation specific to this occurrence',
+		}),
+	),
+	instance: Type.Optional(
+		Type.String({ description: 'Request path that produced the problem' }),
+	),
+	reason: Type.String({ description: 'Stable UPPER_SNAKE error code' }),
+	metadata: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+	reference: Type.Optional(
+		Type.String({
+			description:
+        'Error tracking reference, present when the error was reported',
+		}),
+	),
+}
+
+/**
+ * RFC 9457 problem details with package extensions.
+ */
+export const Problem = Type.Object(problemProperties, { $id: 'Problem' })
+
+export type Problem = Static<typeof Problem>
+
+/**
+ * A 422 problem carrying one entry per invalid field.
+ */
+export const ValidationProblem = Type.Object(
+	{
+		...problemProperties,
+		errors: Type.Array(ProblemFieldError),
+	},
+	{ $id: 'ValidationProblem' },
+)
+
+export type ValidationProblem = Static<typeof ValidationProblem>
+
+/**
+ * Extension members that can be merged into a problem at serialization time.
+ */
+export type ProblemExtra = {
+	instance?: string;
+	reference?: string;
+}
+
+/**
+ * Options accepted by the onError factory for a single occurrence.
+ */
+export type ApiErrorOptions = {
+	title?: string;
+	detail?: string;
+	cause?: unknown;
+}
+
+/**
+ * A thrown API error. Serialized to an RFC 9457 problem by the problems() plugin.
+ */
+export class ApiError<
+	Reason extends string = string,
+	Meta = unknown,
+> extends Error {
+	readonly status: number
+	readonly reason: Reason
+	readonly metadata: Meta
+	readonly title: string
+	readonly detail?: string
+	readonly type: string
+
+	constructor(input: {
+		status: number;
+		reason: Reason;
+		metadata: Meta;
+		title: string;
+		detail?: string;
+		type: string;
+		cause?: unknown;
+	}) {
+		super(
+			input.title,
+			input.cause === undefined ? undefined : { cause: input.cause },
+		)
+		this.name = 'ApiError'
+		this.status = input.status
+		this.reason = input.reason
+		this.metadata = input.metadata
+		this.title = input.title
+		this.detail = input.detail
+		this.type = input.type
+	}
+
+	/**
+   * Serializes the error to an RFC 9457 problem. The cause is never included.
+   * @param extra - Extension members (instance, reference) to merge
+   */
+	public toProblem = (extra: ProblemExtra = {}): Problem => {
+		const problem: Problem = {
+			type: this.type,
+			title: this.title,
+			status: this.status,
+			reason: this.reason,
+		}
+
+		if (this.detail !== undefined) problem.detail = this.detail
+		if (extra.instance !== undefined) problem.instance = extra.instance
+		if (this.metadata !== undefined)
+			problem.metadata = this.metadata as Record<string, unknown>
+		if (extra.reference !== undefined) problem.reference = extra.reference
+
+		return problem
+	}
+}
+
+/**
+ * Metadata type of an error table entry.
+ */
+export type ErrorMetadata<E extends ErrorEntry<any>> =
+  E['metadata'] extends TObject ? Static<E['metadata']> : undefined
+
+/**
+ * Arguments of the onError factory after the reason: metadata is required if the entry has a schema.
+ */
+export type ErrorArgs<E extends ErrorEntry<any>> = E['metadata'] extends TObject
+	? [metadata: Static<E['metadata']>, options?: ApiErrorOptions]
+	: [metadata?: undefined, options?: ApiErrorOptions]
+
+type UnionToIntersection<U> = (
+	U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+	? I
+	: never
+
+/**
+ * One call signature per reason; intersected they behave as overloads, keeping each metadata type concrete.
+ */
+export type ErrorSignatures<Errors extends ErrorTable> = UnionToIntersection<
+{
+	[R in keyof Errors & string]: (
+		reason: R,
+		...args: ErrorArgs<Errors[R]>
+	) => ApiError<R, ErrorMetadata<Errors[R]>>;
+}[keyof Errors & string]
+>
+
+/**
+ * Factory producing typed ApiErrors from an error table. The package defaults are always callable, overridable by key.
+ */
+export type ErrorFactory<Errors extends ErrorTable> = ErrorSignatures<
+MergedErrors<DefaultErrors, Errors>
+> & {
+	/** Wraps an unexpected failure as a 5xx error; the cause is reported but never serialized */
+	unexpected(
+		cause: unknown,
+		options?: ApiErrorOptions & { reason?: keyof Errors & string },
+	): ApiError<string, undefined>;
+}
+
+/** Converts UPPER_SNAKE to Title Case */
+const toTitleCase = (reason: string) =>
+	reason
+		.toLowerCase()
+		.split(/[_\s]+/)
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ')
+
+const resolveCopy = (copy: ErrorEntry<any>['title'], metadata: unknown) =>
+	typeof copy === 'function' ? copy(metadata as any) : copy
+
+/**
+ * Creates an onError factory bound to an effective error configuration. The package defaults back any missing entry.
+ * @param config - The effective error configuration; `type` defaults to 'about:blank'
+ */
+export const createErrorFactory = <Errors extends ErrorTable>(
+	config: ErrorConfig<Errors> = {},
+): ErrorFactory<Errors> => {
+	const typeOf = config.type ?? (() => 'about:blank')
+	const table: ErrorTable = { ...DEFAULT_ERRORS, ...config.table }
+
+	const lookup = (reason: string) => {
+		const entry = table[reason]
+		if (!entry) throw new TypeError(`Unknown error reason "${reason}"`)
+		return entry
+	}
+
+	const create = (
+		reason: string,
+		metadata?: unknown,
+		options: ApiErrorOptions = {},
+	) => {
+		const entry = lookup(reason)
+
+		if (entry.metadata) {
+			if (!Value.Check(entry.metadata, metadata)) {
+				const first = Value.Errors(entry.metadata, metadata).First()
+				throw new TypeError(
+					`Invalid metadata for error "${reason}"${first ? `: ${first.path || '/'} ${first.message}` : ''}`,
+				)
+			}
+		} else {
+			metadata = undefined
+		}
+
+		return new ApiError({
+			status: entry.status,
+			reason,
+			metadata,
+			title:
+        options.title ??
+        resolveCopy(entry.title, metadata) ??
+        toTitleCase(reason),
+			detail: options.detail ?? resolveCopy(entry.detail, metadata),
+			type: typeOf(reason),
+			cause: options.cause,
+		})
+	}
+
+	const factory = ((
+		reason: string,
+		metadata?: unknown,
+		options?: ApiErrorOptions,
+	) => create(reason, metadata, options)) as unknown as ErrorFactory<Errors>
+
+	factory.unexpected = (cause, options = {}) => {
+		const reason = options.reason ?? 'INTERNAL'
+		const entry = lookup(reason)
+		if (entry.status < 500)
+			throw new TypeError(
+				`Error reason "${reason}" has status ${entry.status}, unexpected() requires a 5xx reason`,
+			)
+
+		return create(reason, undefined, {
+			title: options.title,
+			detail: options.detail,
+			cause,
+		}) as ApiError<string, undefined>
+	}
+
+	return factory
+}
+
+/**
+ * Merges two error configurations. The child's table entries and type function win.
+ */
+export const mergeErrors = <
+	Parent extends ErrorTable,
+	Child extends ErrorTable,
+>(
+	parent: ErrorConfig<Parent> | undefined,
+	child: ErrorConfig<Child> | undefined,
+): ErrorConfig<MergedErrors<Parent, Child>> => ({
+	...((child?.type ?? parent?.type)
+		? { type: child?.type ?? parent?.type }
+		: {}),
+	table: { ...parent?.table, ...child?.table } as MergedErrors<Parent, Child>,
+})
+
+/**
+ * The error table resulting from merging a child table onto a parent table.
+ */
+export type MergedErrors<
+	Parent extends ErrorTable,
+	Child extends ErrorTable,
+> = Simplify<Omit<Parent, keyof Child> & Child>
+
+/**
+ * Unique, sorted statuses documented for a table, including the package defaults.
+ */
+export const statusesOf = (table: ErrorTable): number[] =>
+	[
+		...new Set(
+			Object.values({ ...DEFAULT_ERRORS, ...table }).map(
+				(entry) => entry.status,
+			),
+		),
+	].sort((a, b) => a - b)
+
+/**
+ * Identity helper that types the `title` / `detail` functions of an entry from its `metadata` schema,
+ * so they can be written inline without annotating the metadata parameter.
+ * @param entry - The error entry
+ */
+export function defineError<const S extends number, M extends TObject>(entry: {
+	status: S;
+	metadata: M;
+	title?: string | ((metadata: Static<M>) => string);
+	detail?: string | ((metadata: Static<M>) => string);
+}): {
+	status: S;
+	metadata: M;
+	title?: string | ((metadata: Static<M>) => string);
+	detail?: string | ((metadata: Static<M>) => string);
+}
+export function defineError<const S extends number>(entry: {
+	status: S;
+	metadata?: undefined;
+	title?: string | (() => string);
+	detail?: string | (() => string);
+}): {
+	status: S;
+	metadata?: undefined;
+	title?: string | (() => string);
+	detail?: string | (() => string);
+}
+export function defineError(entry: ErrorEntry<any>) {
+	return entry
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,12 @@ export {
 
 export type { ErrorTable, ErrorFactory } from './error'
 
-export { problems } from './problems'
+export { resolveProblem, problemResponse } from './problems'
 
-export type { ProblemsOptions } from './problems'
+export type { ResolveProblemOptions } from './problems'
+
+export { procedures, procedureModels, sentryReporter } from './plugin'
+
+export type { ProceduresOptions, ProblemReporter } from './plugin'
 
 export type { Context, Config, Decorations, ObjectSchema } from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ export type { ResolveProblemOptions } from './problems'
 
 export { procedures, procedureModels, sentryReporter } from './plugin'
 
-export type { ProceduresOptions, ProblemReporter } from './plugin'
+export type { ProceduresOptions, ProblemReporter, ProblemLogger, SentryReporterOptions, SentryLike } from './plugin'
+
+export { configureTracing } from './trace'
+
+export type { TracingOptions, SpanType } from './trace'
 
 export type { Context, Config, Decorations, ObjectSchema } from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,24 @@
 // we need this for type format support
-import { } from 'elysia'
+import {} from 'elysia'
+
+export { createProcedure } from './procedure'
+
+export type { Middleware, Procedure } from './procedure'
+
+export type { Action } from './action'
 
 export {
-	createProcedure
-} from './procedure'
+	ApiError,
+	Problem,
+	ValidationProblem,
+	ProblemFieldError,
+	defineError,
+} from './error'
 
-export type {
-	Middleware,
-	Procedure,
-} from './procedure'
+export type { ErrorTable, ErrorFactory } from './error'
 
-export type {
-	Action
-} from './action'
+export { problems } from './problems'
 
-export type {
-	Context
-} from './utils'
+export type { ProblemsOptions } from './problems'
+
+export type { Context, Config, Decorations } from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,4 +21,4 @@ export { problems } from './problems'
 
 export type { ProblemsOptions } from './problems'
 
-export type { Context, Config, Decorations } from './utils'
+export type { Context, Config, Decorations, ObjectSchema } from './utils'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,125 @@
+// import dependencies
+import { Elysia } from 'elysia'
+import { ApiError, Problem, ValidationProblem } from './error'
+import { resolveProblem, problemResponse } from './problems'
+
+// import types
+import type { Promisable } from 'type-fest'
+import type { ErrorConfig } from './error'
+import type { ResolveProblemOptions } from './problems'
+
+/**
+ * Reports a failure to an error tracker and returns the reference to expose in the problem, if any.
+ */
+export type ProblemReporter = (error: unknown, problem: Problem | ValidationProblem) => Promisable<string | undefined>
+
+/**
+ * Logs one handled failure.
+ */
+export type ProblemLogger = (level: 'warn' | 'error', fields: Record<string, unknown>) => void
+
+/**
+ * Options for the procedures() plugin, grouped by concern.
+ */
+export type ProceduresOptions = {
+	/** The wire contract: error configuration for the problems the plugin builds itself, so copy and `type` URIs line up with the procedures, and echo limits */
+	errors?: ErrorConfig & Pick<ResolveProblemOptions, 'receivedMaxLength'>
+	/** Policy: how handled failures are reported and logged */
+	observability?: {
+		/** Reports failures and yields the `reference`; default: the Sentry policy of sentryReporter() */
+		errorReporting?: ProblemReporter
+		/** Logs handled failures; default console.warn for 4xx and console.error for 5xx */
+		logging?: ProblemLogger
+	}
+}
+
+/**
+ * Options for the default Sentry reporter.
+ */
+export type SentryReporterOptions = {
+	/** Report 4xx ApiErrors as messages: 'off' (default), 'warn' (level warning) or 'all' (level info) */
+	captureClientErrors?: 'off' | 'warn' | 'all'
+}
+
+type Sentry = {
+	captureException: (error: unknown, context?: Record<string, unknown>) => string
+	captureMessage: (message: string, context?: Record<string, unknown>) => string
+}
+
+/** Resolves the optional sentry dependency once */
+let sentry: Promise<Sentry | undefined> | undefined
+const loadSentry = () => sentry ??= (async () => {
+	try {
+		// @ts-expect-error dynamic import of optional dependency
+		const module = await import('@sentry/bun')
+		return typeof module.captureException === 'function' ? module as Sentry : undefined
+	} catch {
+		return undefined
+	}
+})()
+
+/**
+ * The default reporter: 5xx problems are captured as exceptions (Sentry follows the `cause` chain), 4xx ApiErrors
+ * optionally as messages. Sentry is loaded through a dynamic import and skipped when `@sentry/bun` is not installed.
+ */
+export const sentryReporter = (options: SentryReporterOptions = {}): ProblemReporter => {
+	const capture = options.captureClientErrors ?? 'off'
+
+	return async (error, problem) => {
+		const tags = { reason: problem.reason, status: problem.status }
+
+		if (problem.status >= 500) return (await loadSentry())?.captureException(error, { tags })
+		if (error instanceof ApiError && capture !== 'off') {
+			(await loadSentry())?.captureMessage(error.title, { level: capture === 'warn' ? 'warning' : 'info', tags })
+		}
+		return undefined
+	}
+}
+
+/** Extracts the message to log for a failure; never exposed in the body */
+const messageOf = (error: unknown) => {
+	if (error instanceof ApiError) return error.cause instanceof Error ? error.cause.message : error.message
+	return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Registers the `Problem` and `ValidationProblem` models that `action.docs` reference, and `ApiError` as a known error.
+ * Use this instead of procedures() when bringing your own `onError` handler.
+ */
+export const procedureModels = () => new Elysia({ name: 'elysia-procedures/models' })
+	.model({ Problem, ValidationProblem })
+	.error({ API_ERROR: ApiError })
+
+/**
+ * The Elysia integration of elysia-procedures. Registers the problem models and serializes every failure to an
+ * RFC 9457 `application/problem+json` response, reporting and logging it. Mount it once on the root app before any
+ * sub-apps. Redirects, thrown Responses and `status(...)` values pass through.
+ */
+export const procedures = (options: ProceduresOptions = {}) => {
+	const { receivedMaxLength, ...errors } = options.errors ?? {}
+	const report = options.observability?.errorReporting ?? sentryReporter()
+	const log = options.observability?.logging ?? ((level, fields) => console[level](fields))
+
+	return new Elysia({ name: 'elysia-procedures' })
+		.use(procedureModels())
+		.onError({ as: 'global' }, async ({ code, error, request, set }) => {
+			const instance = new URL(request.url).pathname
+			const resolved = resolveProblem(code, error, { errors, receivedMaxLength, instance })
+			if (!resolved) return
+
+			const reference = await report(error, resolved)
+			const problem = reference === undefined ? resolved : { ...resolved, reference }
+
+			log(problem.status >= 500 ? 'error' : 'warn', {
+				status: problem.status,
+				reason: problem.reason,
+				instance,
+				method: request.method,
+				...(reference !== undefined ? { reference } : {}),
+				...(problem.status >= 500 ? { message: messageOf(error) } : {}),
+			})
+
+			set.status = problem.status
+			return problemResponse(problem)
+		})
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,15 +24,19 @@ export type ProblemLogger = (level: 'warn' | 'error', fields: Record<string, unk
  * Options for the procedures() plugin, grouped by concern.
  */
 export type ProceduresOptions = {
-	/** The wire contract: error configuration for the problems the plugin builds itself, so copy and `type` URIs line up with the procedures, and echo limits */
+	/**
+	 * Error configuration for the problems the plugin builds itself (validation, parse and unknown route failures).
+	 * Pass the same `type` function and overrides as the procedures so copy and `type` URIs line up. Also holds the
+	 * limit on how much of a received value is echoed back in validation problems.
+	 */
 	errors?: ErrorConfig & Pick<ResolveProblemOptions, 'receivedMaxLength'>
-	/** Policy: how handled failures are reported and logged, and whether runs are traced */
+	/** How handled failures are reported and logged, and whether runs are traced */
 	observability?: {
-		/** Reports failures and yields the `reference`; default: none, problems carry no `reference` */
+		/** Reports failures and returns the `reference` to expose. Without one nothing is reported and problems carry no `reference` */
 		errorReporting?: ProblemReporter
-		/** Logs handled failures; default console.warn for 4xx and console.error for 5xx */
+		/** Logs handled failures. Defaults to console.warn for 4xx and console.error for 5xx */
 		logging?: ProblemLogger
-		/** Traces procedure and action runs through the OpenTelemetry API; default: off */
+		/** Traces procedure and action runs through the OpenTelemetry API. Off by default */
 		tracing?: TracingOptions | boolean
 	}
 }
@@ -41,7 +45,7 @@ export type ProceduresOptions = {
  * Options for the Sentry reporter.
  */
 export type SentryReporterOptions = {
-	/** Report 4xx ApiErrors as messages: 'off' (default), 'warn' (level warning) or 'all' (level info) */
+	/** Whether to capture 4xx ApiErrors as messages: 'off' (default), 'warn' (at level warning) or 'all' (at level info) */
 	captureClientErrors?: 'off' | 'warn' | 'all'
 }
 
@@ -54,8 +58,9 @@ export type SentryLike = {
 }
 
 /**
- * A reporter for Sentry: 5xx problems are captured as exceptions (Sentry follows the `cause` chain), 4xx ApiErrors
- * optionally as messages. Pass the SDK you initialized, e.g. `sentryReporter(Sentry)` with `import * as Sentry from '@sentry/bun'`.
+ * A reporter for Sentry. Captures 5xx problems as exceptions (Sentry follows the `cause` chain) and, when enabled,
+ * 4xx ApiErrors as messages. Pass the SDK you initialized, e.g. `sentryReporter(Sentry)` after
+ * `import * as Sentry from '@sentry/bun'`.
  */
 export const sentryReporter = (sentry: SentryLike, options: SentryReporterOptions = {}): ProblemReporter => {
 	const capture = options.captureClientErrors ?? 'off'
@@ -71,24 +76,24 @@ export const sentryReporter = (sentry: SentryLike, options: SentryReporterOption
 	}
 }
 
-/** Extracts the message to log for a failure; never exposed in the body */
+/** The message to log for a failure. It goes to the log only, never into the response */
 const messageOf = (error: unknown) => {
 	if (error instanceof ApiError) return error.cause instanceof Error ? error.cause.message : error.message
 	return error instanceof Error ? error.message : String(error)
 }
 
 /**
- * Registers the `Problem` and `ValidationProblem` models that `action.docs` reference, and `ApiError` as a known error.
- * Use this instead of procedures() when bringing your own `onError` handler.
+ * Registers the `Problem` and `ValidationProblem` models that `action.docs` reference, and `ApiError` as a known
+ * error. Mount this instead of procedures() when you bring your own `onError` handler.
  */
 export const procedureModels = () => new Elysia({ name: 'elysia-procedures/models' })
 	.model({ Problem, ValidationProblem })
 	.error({ API_ERROR: ApiError })
 
 /**
- * The Elysia integration of elysia-procedures. Registers the problem models and serializes every failure to an
- * RFC 9457 `application/problem+json` response, reporting and logging it, and configures tracing. Mount it once on
- * the root app before any sub-apps. Redirects, thrown Responses and `status(...)` values pass through.
+ * The Elysia plugin. Registers the problem models, serializes every failure to an RFC 9457
+ * `application/problem+json` response, reports and logs it, and configures tracing. Mount it once on the root app,
+ * before any sub-apps. Redirects, thrown Responses and `status(...)` values pass through untouched.
  */
 export const procedures = (options: ProceduresOptions = {}) => {
 	const { receivedMaxLength, ...errors } = options.errors ?? {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,11 +2,13 @@
 import { Elysia } from 'elysia'
 import { ApiError, Problem, ValidationProblem } from './error'
 import { resolveProblem, problemResponse } from './problems'
+import { configureTracing } from './trace'
 
 // import types
 import type { Promisable } from 'type-fest'
 import type { ErrorConfig } from './error'
 import type { ResolveProblemOptions } from './problems'
+import type { TracingOptions } from './trace'
 
 /**
  * Reports a failure to an error tracker and returns the reference to expose in the problem, if any.
@@ -24,53 +26,46 @@ export type ProblemLogger = (level: 'warn' | 'error', fields: Record<string, unk
 export type ProceduresOptions = {
 	/** The wire contract: error configuration for the problems the plugin builds itself, so copy and `type` URIs line up with the procedures, and echo limits */
 	errors?: ErrorConfig & Pick<ResolveProblemOptions, 'receivedMaxLength'>
-	/** Policy: how handled failures are reported and logged */
+	/** Policy: how handled failures are reported and logged, and whether runs are traced */
 	observability?: {
-		/** Reports failures and yields the `reference`; default: the Sentry policy of sentryReporter() */
+		/** Reports failures and yields the `reference`; default: none, problems carry no `reference` */
 		errorReporting?: ProblemReporter
 		/** Logs handled failures; default console.warn for 4xx and console.error for 5xx */
 		logging?: ProblemLogger
+		/** Traces procedure and action runs through the OpenTelemetry API; default: off */
+		tracing?: TracingOptions | boolean
 	}
 }
 
 /**
- * Options for the default Sentry reporter.
+ * Options for the Sentry reporter.
  */
 export type SentryReporterOptions = {
 	/** Report 4xx ApiErrors as messages: 'off' (default), 'warn' (level warning) or 'all' (level info) */
 	captureClientErrors?: 'off' | 'warn' | 'all'
 }
 
-type Sentry = {
-	captureException: (error: unknown, context?: Record<string, unknown>) => string
-	captureMessage: (message: string, context?: Record<string, unknown>) => string
+/**
+ * The part of a Sentry SDK the reporter uses; any `@sentry/*` module satisfies it.
+ */
+export type SentryLike = {
+	captureException: (error: unknown, context?: any) => string
+	captureMessage: (message: string, context?: any) => string
 }
 
-/** Resolves the optional sentry dependency once */
-let sentry: Promise<Sentry | undefined> | undefined
-const loadSentry = () => sentry ??= (async () => {
-	try {
-		// @ts-expect-error dynamic import of optional dependency
-		const module = await import('@sentry/bun')
-		return typeof module.captureException === 'function' ? module as Sentry : undefined
-	} catch {
-		return undefined
-	}
-})()
-
 /**
- * The default reporter: 5xx problems are captured as exceptions (Sentry follows the `cause` chain), 4xx ApiErrors
- * optionally as messages. Sentry is loaded through a dynamic import and skipped when `@sentry/bun` is not installed.
+ * A reporter for Sentry: 5xx problems are captured as exceptions (Sentry follows the `cause` chain), 4xx ApiErrors
+ * optionally as messages. Pass the SDK you initialized, e.g. `sentryReporter(Sentry)` with `import * as Sentry from '@sentry/bun'`.
  */
-export const sentryReporter = (options: SentryReporterOptions = {}): ProblemReporter => {
+export const sentryReporter = (sentry: SentryLike, options: SentryReporterOptions = {}): ProblemReporter => {
 	const capture = options.captureClientErrors ?? 'off'
 
-	return async (error, problem) => {
+	return (error, problem) => {
 		const tags = { reason: problem.reason, status: problem.status }
 
-		if (problem.status >= 500) return (await loadSentry())?.captureException(error, { tags })
+		if (problem.status >= 500) return sentry.captureException(error, { tags })
 		if (error instanceof ApiError && capture !== 'off') {
-			(await loadSentry())?.captureMessage(error.title, { level: capture === 'warn' ? 'warning' : 'info', tags })
+			sentry.captureMessage(error.title, { level: capture === 'warn' ? 'warning' : 'info', tags })
 		}
 		return undefined
 	}
@@ -92,13 +87,15 @@ export const procedureModels = () => new Elysia({ name: 'elysia-procedures/model
 
 /**
  * The Elysia integration of elysia-procedures. Registers the problem models and serializes every failure to an
- * RFC 9457 `application/problem+json` response, reporting and logging it. Mount it once on the root app before any
- * sub-apps. Redirects, thrown Responses and `status(...)` values pass through.
+ * RFC 9457 `application/problem+json` response, reporting and logging it, and configures tracing. Mount it once on
+ * the root app before any sub-apps. Redirects, thrown Responses and `status(...)` values pass through.
  */
 export const procedures = (options: ProceduresOptions = {}) => {
 	const { receivedMaxLength, ...errors } = options.errors ?? {}
-	const report = options.observability?.errorReporting ?? sentryReporter()
+	const report = options.observability?.errorReporting ?? (() => undefined)
 	const log = options.observability?.logging ?? ((level, fields) => console[level](fields))
+
+	configureTracing(options.observability?.tracing ?? false)
 
 	return new Elysia({ name: 'elysia-procedures' })
 		.use(procedureModels())

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -69,7 +69,7 @@ export const sentryReporter = (sentry: SentryLike, options: SentryReporterOption
 		const tags = { reason: problem.reason, status: problem.status }
 
 		if (problem.status >= 500) return sentry.captureException(error, { tags })
-		if (error instanceof ApiError && capture !== 'off') {
+		if (ApiError.is(error) && capture !== 'off') {
 			sentry.captureMessage(error.title, { level: capture === 'warn' ? 'warning' : 'info', tags })
 		}
 		return undefined
@@ -78,7 +78,7 @@ export const sentryReporter = (sentry: SentryLike, options: SentryReporterOption
 
 /** The message to log for a failure. It goes to the log only, never into the response */
 const messageOf = (error: unknown) => {
-	if (error instanceof ApiError) return error.cause instanceof Error ? error.cause.message : error.message
+	if (ApiError.is(error)) return error.cause instanceof Error ? error.cause.message : error.message
 	return error instanceof Error ? error.message : String(error)
 }
 

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -12,7 +12,7 @@ import type { Problem, ValidationProblem, ProblemFieldError, ProblemFieldLocatio
 export type ResolveProblemOptions = {
 	/** Request path, exposed as the problem's `instance` */
 	instance?: string
-	/** Error configuration used for the problems built here, so copy and `type` URIs line up with the procedures */
+	/** Error configuration for the problems built here; pass the procedures' so copy and `type` URIs line up */
 	errors?: ErrorConfig
 	/** Maximum characters of `received` echoed per field error; default 200 */
 	receivedMaxLength?: number
@@ -21,7 +21,7 @@ export type ResolveProblemOptions = {
 /** Pointer segments whose value is never echoed back */
 const SENSITIVE = /password|secret|token|key/i
 
-/** Serializes a received value as JSON, eliding sensitive fields, values without a JSON form, and truncating long values */
+/** Serializes a received value as JSON. Returns undefined for sensitive fields and values without a JSON form, and truncates long values */
 const describeReceived = (pointer: string, value: unknown, max: number): string | undefined => {
 	if (pointer.split('/').some(segment => SENSITIVE.test(segment))) return undefined
 
@@ -90,12 +90,13 @@ const factoryFor = (errors?: ErrorConfig) => {
 }
 
 /**
- * Resolves an error caught by Elysia's `onError` into an RFC 9457 problem. This is the wire contract as a pure function:
- * it performs no reporting or logging, never includes raw messages of unexpected errors, and returns `undefined` for
- * values Elysia uses for redirects and early returns (thrown Responses and `status(...)` values), which should pass through.
+ * Resolves an error caught by Elysia's `onError` into an RFC 9457 problem. This is the wire contract as a pure
+ * function. It does no reporting or logging and never includes the raw message of an unexpected error. Thrown
+ * Responses and `status(...)` values, which Elysia uses for redirects and early returns, resolve to `undefined` so
+ * the caller can let them pass through.
  * @param code - Elysia's error code
  * @param error - The caught error
- * @param options - Instance, error configuration and echo limits
+ * @param options - Instance, error configuration and echo limit
  */
 export const resolveProblem = (code: string | number, error: unknown, options: ResolveProblemOptions = {}): Problem | ValidationProblem | undefined => {
 	if (error instanceof Response || error instanceof ElysiaCustomStatusResponse) return undefined
@@ -121,7 +122,7 @@ export const resolveProblem = (code: string | number, error: unknown, options: R
 	if (code === 'INVALID_COOKIE_SIGNATURE') return onError('MALFORMED_REQUEST', undefined, { detail: 'The request carries a cookie with an invalid signature.' }).toProblem({ instance })
 	if (code === 'NOT_FOUND') return onError('NOT_FOUND').toProblem({ instance })
 
-	// anything else, including response validation failures: the server, not the client, is at fault
+	// anything else, including response validation failures, is the server's fault
 	return onError('INTERNAL').toProblem({ instance })
 }
 

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -1,0 +1,231 @@
+// import dependencies
+import { Elysia, ElysiaCustomStatusResponse } from 'elysia'
+import {
+	ApiError,
+	Problem,
+	ValidationProblem,
+	createErrorFactory,
+} from './error'
+
+// import types
+import type { ValidationError } from 'elysia'
+import type {
+	ProblemFieldError,
+	ProblemFieldLocation,
+	ErrorConfig,
+} from './error'
+
+/**
+ * Options for the problems() plugin.
+ */
+export type ProblemsOptions = {
+	/** Report 4xx ApiErrors to Sentry as messages: 'off' (default), 'warn' (level warning) or 'all' (level info) */
+	captureClientErrors?: 'off' | 'warn' | 'all';
+	/** Error configuration used for the problems the plugin builds itself, so copy and `type` URIs line up with the procedures */
+	errors?: ErrorConfig;
+	/** Maximum characters of `received` echoed per field error; default 200 */
+	receivedMaxLength?: number;
+	/** Override logging; default console.warn for 4xx and console.error for 5xx */
+	log?: (level: 'warn' | 'error', fields: Record<string, unknown>) => void;
+}
+
+type Sentry = {
+	captureException: (
+		error: unknown,
+		context?: Record<string, unknown>,
+	) => string;
+	captureMessage: (
+		message: string,
+		context?: Record<string, unknown>,
+	) => string;
+}
+
+/** Pointer segments whose value is never echoed back */
+const SENSITIVE = /password|secret|token|key/i
+
+/** Resolves the optional sentry dependency once */
+let sentry: Promise<Sentry | undefined> | undefined
+const loadSentry = () =>
+	(sentry ??= (async () => {
+		try {
+			// @ts-expect-error dynamic import of optional dependency
+			const module = await import('@sentry/bun')
+			return typeof module.captureException === 'function'
+				? (module as Sentry)
+				: undefined
+		} catch {
+			return undefined
+		}
+	})())
+
+/** Serializes a received value as JSON, eliding sensitive fields, values without a JSON form, and truncating long values */
+const describeReceived = (
+	pointer: string,
+	value: unknown,
+	max: number,
+): string | undefined => {
+	if (pointer.split('/').some((segment) => SENSITIVE.test(segment)))
+		return undefined
+
+	let json: string | undefined
+	try {
+		json = JSON.stringify(value)
+	} catch {
+		return undefined
+	}
+
+	if (json === undefined) return undefined
+	return json.length > max ? `${json.slice(0, max)}…` : json
+}
+
+/** Elysia's request validation targets mapped onto the OpenAPI location vocabulary */
+const LOCATIONS = {
+	body: 'body',
+	params: 'path',
+	query: 'query',
+	headers: 'header',
+	cookie: 'cookie',
+} as const satisfies Record<string, ProblemFieldLocation>
+
+const isRequestValidation = (
+	error: ValidationError,
+): error is ValidationError & { type: keyof typeof LOCATIONS } =>
+	error.type in LOCATIONS
+
+/** Builds the field errors of a validation error */
+const fieldErrors = (
+	error: ValidationError,
+	max: number,
+): ProblemFieldError[] => {
+	const all = error.all.filter(
+		(item): item is Extract<typeof item, { path: string }> => 'path' in item,
+	)
+	return all.map((item) => {
+		const field: ProblemFieldError = {
+			in: LOCATIONS[error.type as keyof typeof LOCATIONS],
+			pointer: `#${item.path}`,
+			detail: item.summary ?? item.message,
+		}
+
+		const received = describeReceived(item.path, item.value, max)
+		if (received !== undefined) field.received = received
+
+		return field
+	})
+}
+
+/** Builds the detail line of a validation problem, listing at most five fields */
+const describeFields = (errors: ProblemFieldError[]) => {
+	const names = errors.map(
+		(field: ProblemFieldError) =>
+			field.in +
+      field.pointer
+      	.slice(1)
+      	.split('/')
+      	.filter(Boolean)
+      	.map((segment) =>
+      		/^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`,
+      	)
+      	.join(''),
+	)
+	const listed = names.slice(0, 5).join(', ') + (names.length > 5 ? ', …' : '')
+	return `${names.length} field${names.length === 1 ? ' is' : 's are'} invalid: ${listed}`
+}
+
+/**
+ * Elysia plugin serializing every failure to an RFC 9457 `application/problem+json` response.
+ * Redirects, thrown Responses and `status(...)` values are returned untouched.
+ */
+export const problems = (options: ProblemsOptions = {}) => {
+	const capture = options.captureClientErrors ?? 'off'
+	const receivedMaxLength = options.receivedMaxLength ?? 200
+	const log = options.log ?? ((level, fields) => console[level](fields))
+	const onError = createErrorFactory(options.errors)
+
+	return new Elysia({ name: 'elysia-procedures/problems' })
+		.model({ Problem, ValidationProblem })
+		.error({ API_ERROR: ApiError })
+		.onError({ as: 'global' }, async ({ code, error, request, set }) => {
+			// elysia uses these for redirects and early returns
+			if (
+				error instanceof Response ||
+        error instanceof ElysiaCustomStatusResponse
+			)
+				return
+
+			const instance = new URL(request.url).pathname
+			const fields: Record<string, unknown> = {
+				instance,
+				method: request.method,
+			}
+			let problem: Problem | ValidationProblem
+
+			if (error instanceof ApiError) {
+				let reference: string | undefined
+				if (error.status >= 500) {
+					reference = (await loadSentry())?.captureException(error, {
+						tags: { reason: error.reason, status: error.status },
+					})
+					fields.message =
+            error.cause instanceof Error ? error.cause.message : error.message
+				} else if (capture !== 'off') {
+					(await loadSentry())?.captureMessage(error.title, {
+						level: capture === 'warn' ? 'warning' : 'info',
+						tags: { reason: error.reason, status: error.status },
+					})
+				}
+				problem = error.toProblem({ instance, reference })
+			} else if (
+				code === 'VALIDATION' &&
+        isRequestValidation(error as ValidationError)
+			) {
+				const errors = fieldErrors(error as ValidationError, receivedMaxLength)
+				problem = {
+					...onError('INVALID_INPUT', undefined, {
+						detail: describeFields(errors),
+					}).toProblem({ instance }),
+					errors,
+				}
+			} else if (code === 'INVALID_FILE_TYPE') {
+				const { property, message } = error as Error & { property: string }
+				const errors: ProblemFieldError[] = [
+					{ in: 'body', pointer: `#/${property}`, detail: message },
+				]
+				problem = {
+					...onError('INVALID_INPUT', undefined, {
+						detail: describeFields(errors),
+					}).toProblem({ instance }),
+					errors,
+				}
+			} else if (code === 'PARSE') {
+				problem = onError('MALFORMED_REQUEST', undefined, {
+					detail: 'The request body could not be parsed.',
+				}).toProblem({ instance })
+			} else if (code === 'INVALID_COOKIE_SIGNATURE') {
+				problem = onError('MALFORMED_REQUEST', undefined, {
+					detail: 'The request carries a cookie with an invalid signature.',
+				}).toProblem({ instance })
+			} else if (code === 'NOT_FOUND') {
+				problem = onError('NOT_FOUND').toProblem({ instance })
+			} else {
+				// includes response validation failures: the handler, not the client, produced an invalid value
+				const reference = (await loadSentry())?.captureException(error)
+				if (reference !== undefined) fields.reference = reference
+				fields.message = error instanceof Error ? error.message : String(error)
+				problem = onError('INTERNAL').toProblem({ instance, reference })
+			}
+
+			log(problem.status >= 500 ? 'error' : 'warn', {
+				status: problem.status,
+				reason: problem.reason,
+				...fields,
+				...(problem.reference ? { reference: problem.reference } : {}),
+			})
+
+			set.status = problem.status
+			return new Response(JSON.stringify(problem), {
+				status: problem.status,
+				headers: { 'content-type': 'application/problem+json' },
+			})
+		})
+}

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -1,71 +1,29 @@
 // import dependencies
-import { Elysia, ElysiaCustomStatusResponse } from 'elysia'
-import {
-	ApiError,
-	Problem,
-	ValidationProblem,
-	createErrorFactory,
-} from './error'
+import { ElysiaCustomStatusResponse } from 'elysia'
+import { ApiError, createErrorFactory } from './error'
 
 // import types
 import type { ValidationError } from 'elysia'
-import type {
-	ProblemFieldError,
-	ProblemFieldLocation,
-	ErrorConfig,
-} from './error'
+import type { Problem, ValidationProblem, ProblemFieldError, ProblemFieldLocation, ErrorConfig, ErrorFactory, NoErrors } from './error'
 
 /**
- * Options for the problems() plugin.
+ * Options for resolving an Elysia error into a problem.
  */
-export type ProblemsOptions = {
-	/** Report 4xx ApiErrors to Sentry as messages: 'off' (default), 'warn' (level warning) or 'all' (level info) */
-	captureClientErrors?: 'off' | 'warn' | 'all';
-	/** Error configuration used for the problems the plugin builds itself, so copy and `type` URIs line up with the procedures */
-	errors?: ErrorConfig;
+export type ResolveProblemOptions = {
+	/** Request path, exposed as the problem's `instance` */
+	instance?: string
+	/** Error configuration used for the problems built here, so copy and `type` URIs line up with the procedures */
+	errors?: ErrorConfig
 	/** Maximum characters of `received` echoed per field error; default 200 */
-	receivedMaxLength?: number;
-	/** Override logging; default console.warn for 4xx and console.error for 5xx */
-	log?: (level: 'warn' | 'error', fields: Record<string, unknown>) => void;
-}
-
-type Sentry = {
-	captureException: (
-		error: unknown,
-		context?: Record<string, unknown>,
-	) => string;
-	captureMessage: (
-		message: string,
-		context?: Record<string, unknown>,
-	) => string;
+	receivedMaxLength?: number
 }
 
 /** Pointer segments whose value is never echoed back */
 const SENSITIVE = /password|secret|token|key/i
 
-/** Resolves the optional sentry dependency once */
-let sentry: Promise<Sentry | undefined> | undefined
-const loadSentry = () =>
-	(sentry ??= (async () => {
-		try {
-			// @ts-expect-error dynamic import of optional dependency
-			const module = await import('@sentry/bun')
-			return typeof module.captureException === 'function'
-				? (module as Sentry)
-				: undefined
-		} catch {
-			return undefined
-		}
-	})())
-
 /** Serializes a received value as JSON, eliding sensitive fields, values without a JSON form, and truncating long values */
-const describeReceived = (
-	pointer: string,
-	value: unknown,
-	max: number,
-): string | undefined => {
-	if (pointer.split('/').some((segment) => SENSITIVE.test(segment)))
-		return undefined
+const describeReceived = (pointer: string, value: unknown, max: number): string | undefined => {
+	if (pointer.split('/').some(segment => SENSITIVE.test(segment))) return undefined
 
 	let json: string | undefined
 	try {
@@ -87,20 +45,12 @@ const LOCATIONS = {
 	cookie: 'cookie',
 } as const satisfies Record<string, ProblemFieldLocation>
 
-const isRequestValidation = (
-	error: ValidationError,
-): error is ValidationError & { type: keyof typeof LOCATIONS } =>
-	error.type in LOCATIONS
+const isRequestValidation = (error: ValidationError): error is ValidationError & { type: keyof typeof LOCATIONS } => error.type in LOCATIONS
 
 /** Builds the field errors of a validation error */
-const fieldErrors = (
-	error: ValidationError,
-	max: number,
-): ProblemFieldError[] => {
-	const all = error.all.filter(
-		(item): item is Extract<typeof item, { path: string }> => 'path' in item,
-	)
-	return all.map((item) => {
+const fieldErrors = (error: ValidationError, max: number): ProblemFieldError[] => {
+	const all = error.all.filter((item): item is Extract<typeof item, { path: string }> => 'path' in item)
+	return all.map(item => {
 		const field: ProblemFieldError = {
 			in: LOCATIONS[error.type as keyof typeof LOCATIONS],
 			pointer: `#${item.path}`,
@@ -114,118 +64,71 @@ const fieldErrors = (
 	})
 }
 
+/** Converts a field error like { in: 'body', pointer: '#/tags/1' } to body.tags[1] */
+const humanizeField = (field: ProblemFieldError) => field.in + field.pointer
+	.slice(1)
+	.split('/')
+	.filter(Boolean)
+	.map(segment => /^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`)
+	.join('')
+
 /** Builds the detail line of a validation problem, listing at most five fields */
 const describeFields = (errors: ProblemFieldError[]) => {
-	const names = errors.map(
-		(field: ProblemFieldError) =>
-			field.in +
-      field.pointer
-      	.slice(1)
-      	.split('/')
-      	.filter(Boolean)
-      	.map((segment) =>
-      		/^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`,
-      	)
-      	.join(''),
-	)
+	const names = errors.map(humanizeField)
 	const listed = names.slice(0, 5).join(', ') + (names.length > 5 ? ', …' : '')
 	return `${names.length} field${names.length === 1 ? ' is' : 's are'} invalid: ${listed}`
 }
 
-/**
- * Elysia plugin serializing every failure to an RFC 9457 `application/problem+json` response.
- * Redirects, thrown Responses and `status(...)` values are returned untouched.
- */
-export const problems = (options: ProblemsOptions = {}) => {
-	const capture = options.captureClientErrors ?? 'off'
-	const receivedMaxLength = options.receivedMaxLength ?? 200
-	const log = options.log ?? ((level, fields) => console[level](fields))
-	const onError = createErrorFactory(options.errors)
-
-	return new Elysia({ name: 'elysia-procedures/problems' })
-		.model({ Problem, ValidationProblem })
-		.error({ API_ERROR: ApiError })
-		.onError({ as: 'global' }, async ({ code, error, request, set }) => {
-			// elysia uses these for redirects and early returns
-			if (
-				error instanceof Response ||
-        error instanceof ElysiaCustomStatusResponse
-			)
-				return
-
-			const instance = new URL(request.url).pathname
-			const fields: Record<string, unknown> = {
-				instance,
-				method: request.method,
-			}
-			let problem: Problem | ValidationProblem
-
-			if (error instanceof ApiError) {
-				let reference: string | undefined
-				if (error.status >= 500) {
-					reference = (await loadSentry())?.captureException(error, {
-						tags: { reason: error.reason, status: error.status },
-					})
-					fields.message =
-            error.cause instanceof Error ? error.cause.message : error.message
-				} else if (capture !== 'off') {
-					(await loadSentry())?.captureMessage(error.title, {
-						level: capture === 'warn' ? 'warning' : 'info',
-						tags: { reason: error.reason, status: error.status },
-					})
-				}
-				problem = error.toProblem({ instance, reference })
-			} else if (
-				code === 'VALIDATION' &&
-        isRequestValidation(error as ValidationError)
-			) {
-				const errors = fieldErrors(error as ValidationError, receivedMaxLength)
-				problem = {
-					...onError('INVALID_INPUT', undefined, {
-						detail: describeFields(errors),
-					}).toProblem({ instance }),
-					errors,
-				}
-			} else if (code === 'INVALID_FILE_TYPE') {
-				const { property, message } = error as Error & { property: string }
-				const errors: ProblemFieldError[] = [
-					{ in: 'body', pointer: `#/${property}`, detail: message },
-				]
-				problem = {
-					...onError('INVALID_INPUT', undefined, {
-						detail: describeFields(errors),
-					}).toProblem({ instance }),
-					errors,
-				}
-			} else if (code === 'PARSE') {
-				problem = onError('MALFORMED_REQUEST', undefined, {
-					detail: 'The request body could not be parsed.',
-				}).toProblem({ instance })
-			} else if (code === 'INVALID_COOKIE_SIGNATURE') {
-				problem = onError('MALFORMED_REQUEST', undefined, {
-					detail: 'The request carries a cookie with an invalid signature.',
-				}).toProblem({ instance })
-			} else if (code === 'NOT_FOUND') {
-				problem = onError('NOT_FOUND').toProblem({ instance })
-			} else {
-				// includes response validation failures: the handler, not the client, produced an invalid value
-				const reference = (await loadSentry())?.captureException(error)
-				if (reference !== undefined) fields.reference = reference
-				fields.message = error instanceof Error ? error.message : String(error)
-				problem = onError('INTERNAL').toProblem({ instance, reference })
-			}
-
-			log(problem.status >= 500 ? 'error' : 'warn', {
-				status: problem.status,
-				reason: problem.reason,
-				...fields,
-				...(problem.reference ? { reference: problem.reference } : {}),
-			})
-
-			set.status = problem.status
-			return new Response(JSON.stringify(problem), {
-				status: problem.status,
-				headers: { 'content-type': 'application/problem+json' },
-			})
-		})
+/** One error factory per error configuration */
+const factories = new WeakMap<ErrorConfig, ErrorFactory<NoErrors>>()
+const defaultFactory = createErrorFactory()
+const factoryFor = (errors?: ErrorConfig) => {
+	if (!errors) return defaultFactory
+	let factory = factories.get(errors)
+	if (!factory) factories.set(errors, factory = createErrorFactory(errors))
+	return factory
 }
+
+/**
+ * Resolves an error caught by Elysia's `onError` into an RFC 9457 problem. This is the wire contract as a pure function:
+ * it performs no reporting or logging, never includes raw messages of unexpected errors, and returns `undefined` for
+ * values Elysia uses for redirects and early returns (thrown Responses and `status(...)` values), which should pass through.
+ * @param code - Elysia's error code
+ * @param error - The caught error
+ * @param options - Instance, error configuration and echo limits
+ */
+export const resolveProblem = (code: string | number, error: unknown, options: ResolveProblemOptions = {}): Problem | ValidationProblem | undefined => {
+	if (error instanceof Response || error instanceof ElysiaCustomStatusResponse) return undefined
+
+	const { instance } = options
+	const onError = factoryFor(options.errors)
+	const max = options.receivedMaxLength ?? 200
+
+	if (error instanceof ApiError) return error.toProblem({ instance })
+
+	if (code === 'VALIDATION' && isRequestValidation(error as ValidationError)) {
+		const errors = fieldErrors(error as ValidationError, max)
+		return { ...onError('INVALID_INPUT', undefined, { detail: describeFields(errors) }).toProblem({ instance }), errors }
+	}
+
+	if (code === 'INVALID_FILE_TYPE') {
+		const { property, message } = error as Error & { property: string }
+		const errors: ProblemFieldError[] = [{ in: 'body', pointer: `#/${property}`, detail: message }]
+		return { ...onError('INVALID_INPUT', undefined, { detail: describeFields(errors) }).toProblem({ instance }), errors }
+	}
+
+	if (code === 'PARSE') return onError('MALFORMED_REQUEST', undefined, { detail: 'The request body could not be parsed.' }).toProblem({ instance })
+	if (code === 'INVALID_COOKIE_SIGNATURE') return onError('MALFORMED_REQUEST', undefined, { detail: 'The request carries a cookie with an invalid signature.' }).toProblem({ instance })
+	if (code === 'NOT_FOUND') return onError('NOT_FOUND').toProblem({ instance })
+
+	// anything else, including response validation failures: the server, not the client, is at fault
+	return onError('INTERNAL').toProblem({ instance })
+}
+
+/**
+ * Serializes a problem to an `application/problem+json` response.
+ */
+export const problemResponse = (problem: Problem | ValidationProblem) => new Response(JSON.stringify(problem), {
+	status: problem.status,
+	headers: { 'content-type': 'application/problem+json' },
+})

--- a/src/problems.ts
+++ b/src/problems.ts
@@ -18,16 +18,26 @@ export type ResolveProblemOptions = {
 	receivedMaxLength?: number
 }
 
-/** Pointer segments whose value is never echoed back */
+/** Pointer segments and property names whose value is never echoed back */
 const SENSITIVE = /password|secret|token|key/i
 
-/** Serializes a received value as JSON. Returns undefined for sensitive fields and values without a JSON form, and truncates long values */
+/** Placeholder for redacted properties inside an echoed object */
+const REDACTED = '[redacted]'
+
+/** Replaces sensitive properties, at any depth, while JSON.stringify walks the value */
+const redact = (key: string, value: unknown) => (SENSITIVE.test(key) ? REDACTED : value)
+
+/**
+ * Serializes a received value as JSON. Returns undefined for sensitive fields and values without a JSON form, and
+ * truncates long values. Sensitive properties nested inside an object are replaced, so an error reported at the
+ * object level never echoes a secret either.
+ */
 const describeReceived = (pointer: string, value: unknown, max: number): string | undefined => {
 	if (pointer.split('/').some(segment => SENSITIVE.test(segment))) return undefined
 
 	let json: string | undefined
 	try {
-		json = JSON.stringify(value)
+		json = JSON.stringify(value, redact)
 	} catch {
 		return undefined
 	}
@@ -105,7 +115,7 @@ export const resolveProblem = (code: string | number, error: unknown, options: R
 	const onError = factoryFor(options.errors)
 	const max = options.receivedMaxLength ?? 200
 
-	if (error instanceof ApiError) return error.toProblem({ instance })
+	if (ApiError.is(error)) return error.toProblem({ instance })
 
 	if (code === 'VALIDATION' && isRequestValidation(error as ValidationError)) {
 		const errors = fieldErrors(error as ValidationError, max)

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -291,7 +291,7 @@ export class Procedure<
  * Creates a new procedure builder with typed params, query, and body.
  *
  * @param name - Descriptive name for the procedure (used in logs and debugging)
- * @param base - Optional base procedure to inherit from
+ * @param base - Optional base procedure to inherit from; can be left out to pass the config directly
  * @param config - Optional tracing and error configuration, merged on top of the base procedure's
  *
  * @example
@@ -308,21 +308,30 @@ export class Procedure<
  * 	}))
  * ```
  */
-export const createProcedure = <
+export function createProcedure<
+	const ConfigErrors extends ErrorTable = NoErrors
+>(name: string, config?: Config<ConfigErrors>): ProcedureBuilder<Context, undefined, undefined, undefined, ConfigErrors>
+export function createProcedure<
 	Ctx extends Context,
 	Params extends ObjectSchema | undefined = undefined,
 	Query extends ObjectSchema | undefined = undefined,
 	Body extends ObjectSchema | undefined = undefined,
 	BaseErrors extends ErrorTable = NoErrors,
 	const ConfigErrors extends ErrorTable = NoErrors
->(name: string, base?: Procedure<Ctx, Params, Query, Body, BaseErrors>, config: Config<ConfigErrors> = {}) => new ProcedureBuilder<Ctx, Params, Query, Body, MergedErrors<BaseErrors, ConfigErrors>>({
-	params: base?.params as any,
-	query: base?.query as any,
-	body: base?.body as any,
-	middlewares: base?.middlewares ?? [],
-	name,
-	config: {
-		...config,
-		errors: mergeErrors(base?.config.errors, config.errors)
-	}
-})
+>(name: string, base?: Procedure<Ctx, Params, Query, Body, BaseErrors>, config?: Config<ConfigErrors>): ProcedureBuilder<Ctx, Params, Query, Body, MergedErrors<BaseErrors, ConfigErrors>>
+export function createProcedure(name: string, baseOrConfig?: Procedure<any, any, any, any, any> | Config<any>, config: Config<any> = {}) {
+	const base = baseOrConfig instanceof Procedure ? baseOrConfig : undefined
+	if (baseOrConfig && !base) config = baseOrConfig as Config<any>
+
+	return new ProcedureBuilder({
+		params: base?.params,
+		query: base?.query,
+		body: base?.body,
+		middlewares: base?.middlewares ?? [],
+		name,
+		config: {
+			...config,
+			errors: mergeErrors(base?.config.errors, config.errors)
+		}
+	})
+}

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -109,22 +109,13 @@ export class Middleware<
 	 * @param input - The current procedure arguments
 	 * @returns - The additional context created by the middleware to be merged into the procedure
 	 */
-	public execute = async (input: ProcedureFnArgs<Ctx, Params, Query, Body>) => trace({
-		name: this.config.tracing?.name ?? this.name,
-		op: 'procedure.middleware',
-		startTime: performance.timeOrigin + performance.now(),
-		attributes: {
-			'procedure.type': 'middleware',
-			'procedure.name': this.name,
-			...this.config.tracing?.attributes
-		}
+	public execute = async (input: ProcedureFnArgs<Ctx, Params, Query, Body>) => trace('middleware', this.config.tracing?.name ?? this.name, {
+		'procedure.name': this.name,
+		...this.config.tracing?.attributes
 	}, async span => {
 		if (!this._keys) {
-			const result = await this._handler(input, this._onError)
-
 			span?.setAttribute('procedure.cache', 'unavailable')
-			span?.end(performance.timeOrigin + performance.now())
-			return result
+			return await this._handler(input, this._onError)
 		}
 
 		// compute a cache key based on the name and input params, query, and body
@@ -133,11 +124,8 @@ export class Middleware<
 		// check if the middleware has already been executed
 		const cached = cache.get(input.ctx.request) ?? new Map()
 		if (cached.has(key)) {
-			const result = cached.get(key)
-
 			span?.setAttribute('procedure.cache.hit', true)
-			span?.end(performance.timeOrigin + performance.now())
-			return result
+			return cached.get(key)
 		}
 
 		// execute the middleware handler
@@ -146,9 +134,8 @@ export class Middleware<
 		// store the result in the cache, use null for void results
 		cached.set(key, result ?? null)
 		cache.set(input.ctx.request, cached)
-		
+
 		span?.setAttribute('procedure.cache.hit', false)
-		span?.end(performance.timeOrigin + performance.now())
 		return result
 	})
 }

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -2,11 +2,13 @@
 import { ActionBuilder } from './action'
 import { merge } from './utils'
 import { trace } from './trace'
+import { createErrorFactory, mergeErrors } from './error'
 
 // import types
 import type { Static, TObject } from '@sinclair/typebox'
 import type { Promisable, Simplify } from 'type-fest'
 import type { Context, SafeTObject, MergedObject, MergedContext, Decorations, Config } from './utils'
+import type { ErrorFactory, ErrorTable, MergedErrors, NoErrors } from './error'
 
 // define a local middleware cache
 const cache = new WeakMap<Request, Map<string, any>>()
@@ -18,7 +20,8 @@ const cacheKey = (id: string, array: string[]) => `${id}:[${array.join(',')}]`
 export type ProcedureArgs<
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
-	Body extends TObject | undefined
+	Body extends TObject | undefined,
+	Errors extends ErrorTable = NoErrors
 > = {
 	/** TypeBox schema for route parameters */
 	params: Params
@@ -30,8 +33,8 @@ export type ProcedureArgs<
 	middlewares: AnyMiddleware[]
 	/** Name of the procedure for identification */
 	name: string
-	/** Additional configuration for the procedure */
-	config: Config
+	/** Effective configuration for the procedure, including the merged error table */
+	config: Config<Errors>
 }
 
 /**
@@ -61,13 +64,14 @@ export type ProcedureFn<
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
-	Next = object | void
-> = (input: ProcedureFnArgs<Ctx, Params, Query, Body>) => Promisable<Next>
+	Next = object | void,
+	Errors extends ErrorTable = NoErrors
+> = (input: ProcedureFnArgs<Ctx, Params, Query, Body>, onError: ErrorFactory<Errors>) => Promisable<Next>
 
 /**
  * Type alias for any middleware type.
  */
-export type AnyMiddleware = Middleware<any, any, any, any>
+export type AnyMiddleware = Middleware<any, any, any, any, any, any>
 
 /**
  * Middleware class representing a function to run during request processing.
@@ -78,23 +82,26 @@ export class Middleware<
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
 	Body extends TObject | undefined,
-	Next = object | void
+	Next = object | void,
+	Errors extends ErrorTable = NoErrors
 > {
 	private _id: string = crypto.randomUUID()
-	private _handler: ProcedureFn<Ctx, Params, Query, Body, Next>
-	private _keys?: ProcedureFn<Ctx, Params, Query, Body, string[]>
+	private _handler: ProcedureFn<Ctx, Params, Query, Body, Next, Errors>
+	private _keys?: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>
+	private _onError: ErrorFactory<Errors>
 
 	/** Name of the middleware for identification */
 	name: string
 
 	/** Additional configuration for the middleware */
-	config: Config
+	config: Config<Errors>
 
-	constructor(handler: ProcedureFn<Ctx, Params, Query, Body, Next>, name: string, config: Config, keys?: ProcedureFn<Ctx, Params, Query, Body, string[]>) {
+	constructor(handler: ProcedureFn<Ctx, Params, Query, Body, Next, Errors>, name: string, config: Config<Errors>, keys?: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>) {
 		this._handler = handler
 		this._keys = keys
 		this.name = name
 		this.config = config
+		this._onError = createErrorFactory(config.errors)
 	}
 
 	/**
@@ -113,7 +120,7 @@ export class Middleware<
 		}
 	}, async span => {
 		if (!this._keys) {
-			const result = await this._handler(input)
+			const result = await this._handler(input, this._onError)
 
 			span?.setAttribute('procedure.cache', 'unavailable')
 			span?.end(performance.timeOrigin + performance.now())
@@ -121,7 +128,7 @@ export class Middleware<
 		}
 
 		// compute a cache key based on the name and input params, query, and body
-		const key = cacheKey(this._id, await this._keys(input))
+		const key = cacheKey(this._id, await this._keys(input, this._onError))
 
 		// check if the middleware has already been executed
 		const cached = cache.get(input.ctx.request) ?? new Map()
@@ -134,7 +141,7 @@ export class Middleware<
 		}
 
 		// execute the middleware handler
-		const result = await this._handler(input)
+		const result = await this._handler(input, this._onError)
 
 		// store the result in the cache, use null for void results
 		cached.set(key, result ?? null)
@@ -154,13 +161,14 @@ export class ProcedureBuilder<
 	Ctx extends Context,
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
-	Body extends TObject | undefined
+	Body extends TObject | undefined,
+	Errors extends ErrorTable = NoErrors
 > {
-	private _state: ProcedureArgs<Params, Query, Body> & {
-		keys?: ProcedureFn<Ctx, Params, Query, Body, string[]>
+	private _state: ProcedureArgs<Params, Query, Body, Errors> & {
+		keys?: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>
 	}
 
-	constructor(base: ProcedureArgs<Params, Query, Body>) {
+	constructor(base: ProcedureArgs<Params, Query, Body, Errors>) {
 		this._state = base
 	}
 
@@ -175,14 +183,14 @@ export class ProcedureBuilder<
 		Q extends TObject | undefined,
 		B extends TObject | undefined
 	>(
-		changes: Partial<ProcedureArgs<P, Q, B> & {
-			keys?: ProcedureFn<Ctx, Params, Query, Body, string[]>
+		changes: Partial<ProcedureArgs<P, Q, B, Errors> & {
+			keys?: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>
 		}>
-	): ProcedureBuilder<Ctx, P, Q, B> => {
-		return new ProcedureBuilder<Ctx, P, Q, B>({
+	): ProcedureBuilder<Ctx, P, Q, B, Errors> => {
+		return new ProcedureBuilder<Ctx, P, Q, B, Errors>({
 			...this._state,
 			...changes
-		} as ProcedureArgs<P, Q, B>)
+		} as ProcedureArgs<P, Q, B, Errors>)
 	}
 
 	/**
@@ -222,20 +230,20 @@ export class ProcedureBuilder<
 	 * Adds cache keys to the procedure.
 	 * @param keys - The function to compute the cache keys
 	 */
-	public cache = (keys: ProcedureFn<Ctx, Params, Query, Body, string[]>) => this._apply<Params, Query, Body>({ keys })
+	public cache = (keys: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>) => this._apply<Params, Query, Body>({ keys })
 
 	/**
 		 * Builds this procedure with the given handler function.
 		 * @param handler - The function to execute when this procedure is called
 		 * @returns A built procedure with the given handler
 		 */
-	public build = <Next extends object | void>(handler?: ProcedureFn<Ctx, Params, Query, Body, Next>): Procedure<MergedContext<Ctx, Next>, Params, Query, Body> => {
+	public build = <Next extends object | void>(handler?: ProcedureFn<Ctx, Params, Query, Body, Next, Errors>): Procedure<MergedContext<Ctx, Next>, Params, Query, Body, Errors> => {
 		if (handler) {
-			const middleware = new Middleware<Ctx, Params, Query, Body, Next>(handler, this._state.name, this._state.config, this._state.keys)
+			const middleware = new Middleware<Ctx, Params, Query, Body, Next, Errors>(handler, this._state.name, this._state.config, this._state.keys)
 			this._state.middlewares = [...this._state.middlewares, middleware]
 		}
 
-		return new Procedure<MergedContext<Ctx, Next>, Params, Query, Body>(this._state)
+		return new Procedure<MergedContext<Ctx, Next>, Params, Query, Body, Errors>(this._state)
 	}
 }
 
@@ -250,7 +258,8 @@ export class Procedure<
 	Ctx extends Context,
 	Params extends TObject | undefined,
 	Query extends TObject | undefined,
-	Body extends TObject | undefined
+	Body extends TObject | undefined,
+	Errors extends ErrorTable = NoErrors
 > {
 	/** TypeBox schema for route parameters */
 	params: Params
@@ -260,29 +269,33 @@ export class Procedure<
 	body: Body
 	/** Chain of middleware to execute before the main action handler */
 	middlewares: AnyMiddleware[]
+	/** Effective configuration of the procedure, including the merged error table */
+	config: Config<Errors>
 
-	constructor(base: ProcedureArgs<Params, Query, Body>) {
+	constructor(base: ProcedureArgs<Params, Query, Body, Errors>) {
 		this.params = base.params
 		this.query = base.query
 		this.body = base.body
 		this.middlewares = base.middlewares
+		this.config = base.config
 	}
 
 	/**
 	 * Creates a new action from this procedure.
 	 * @param name - Name of the action for identification
-	 * @param details - API documentation details for the action
+	 * @param details - API documentation details for the action, including additional errors
 	 * @returns A new ActionBuilder instance
 	 */
-	public createAction = (name: string, details?: Decorations) => {
-		return new ActionBuilder<Ctx, Params, Query, Body, undefined>({
+	public createAction = <const DetailErrors extends ErrorTable = NoErrors>(name: string, details?: Decorations<DetailErrors>) => {
+		const errors = mergeErrors(this.config.errors, details?.errors)
+		return new ActionBuilder<Ctx, Params, Query, Body, undefined, MergedErrors<Errors, DetailErrors>>({
 			params: this.params,
 			query: this.query,
 			body: this.body,
 			output: undefined,
 			middlewares: this.middlewares,
 			name,
-			details,
+			details: { ...details, errors } as Decorations<MergedErrors<Errors, DetailErrors>>,
 		})
 	}
 }
@@ -292,7 +305,7 @@ export class Procedure<
  *
  * @param name - Descriptive name for the procedure (used in logs and debugging)
  * @param base - Optional base procedure to inherit from
- * @param role - Optional role for authorization purposes
+ * @param config - Optional tracing and error configuration, merged onto the base procedure's
  *
  * @example
  * ```ts
@@ -312,12 +325,17 @@ export const createProcedure = <
 	Ctx extends Context,
 	Params extends TObject | undefined = undefined,
 	Query extends TObject | undefined = undefined,
-	Body extends TObject | undefined = undefined
->(name: string, base?: Procedure<Ctx, Params, Query, Body>, config: Config = {}) => new ProcedureBuilder<Ctx, Params, Query, Body>({
+	Body extends TObject | undefined = undefined,
+	BaseErrors extends ErrorTable = NoErrors,
+	const ConfigErrors extends ErrorTable = NoErrors
+>(name: string, base?: Procedure<Ctx, Params, Query, Body, BaseErrors>, config: Config<ConfigErrors> = {}) => new ProcedureBuilder<Ctx, Params, Query, Body, MergedErrors<BaseErrors, ConfigErrors>>({
 	params: base?.params as any,
 	query: base?.query as any,
 	body: base?.body as any,
 	middlewares: base?.middlewares ?? [],
 	name,
-	config
+	config: {
+		...config,
+		errors: mergeErrors(base?.config.errors, config.errors)
+	}
 })

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -5,9 +5,9 @@ import { trace } from './trace'
 import { createErrorFactory, mergeErrors } from './error'
 
 // import types
-import type { Static, TObject } from '@sinclair/typebox'
+import type { Static } from '@sinclair/typebox'
 import type { Promisable, Simplify } from 'type-fest'
-import type { Context, SafeTObject, MergedObject, MergedContext, Decorations, Config } from './utils'
+import type { Context, ObjectSchema, SafeTObject, MergedObject, MergedContext, Decorations, Config } from './utils'
 import type { ErrorFactory, ErrorTable, MergedErrors, NoErrors } from './error'
 
 // define a local middleware cache
@@ -18,9 +18,9 @@ const cacheKey = (id: string, array: string[]) => `${id}:[${array.join(',')}]`
  * Configuration arguments for creating a procedure.
  */
 export type ProcedureArgs<
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > = {
 	/** TypeBox schema for route parameters */
@@ -42,18 +42,18 @@ export type ProcedureArgs<
  */
 export type ProcedureFnArgs<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined
 > = {
 	/** Context object with request data and middleware results */
 	ctx: Simplify<Ctx>
 	/** Parsed and validated route parameters */
-	params: Params extends TObject ? Static<Params> : undefined
+	params: Params extends ObjectSchema ? Static<Params> : undefined
 	/** Parsed and validated query parameters */
-	query: Query extends TObject ? Static<Query> : undefined
+	query: Query extends ObjectSchema ? Static<Query> : undefined
 	/** Parsed and validated request body */
-	body: Body extends TObject ? Static<Body> : undefined
+	body: Body extends ObjectSchema ? Static<Body> : undefined
 }
 
 /**
@@ -61,9 +61,9 @@ export type ProcedureFnArgs<
  */
 export type ProcedureFn<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Next = object | void,
 	Errors extends ErrorTable = NoErrors
 > = (input: ProcedureFnArgs<Ctx, Params, Query, Body>, onError: ErrorFactory<Errors>) => Promisable<Next>
@@ -79,9 +79,9 @@ export type AnyMiddleware = Middleware<any, any, any, any, any, any>
  */
 export class Middleware<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Next = object | void,
 	Errors extends ErrorTable = NoErrors
 > {
@@ -159,9 +159,9 @@ export class Middleware<
  */
 export class ProcedureBuilder<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > {
 	private _state: ProcedureArgs<Params, Query, Body, Errors> & {
@@ -179,9 +179,9 @@ export class ProcedureBuilder<
 	 * @private
 	 */
 	private _apply = <
-		P extends TObject | undefined,
-		Q extends TObject | undefined,
-		B extends TObject | undefined
+		P extends ObjectSchema | undefined,
+		Q extends ObjectSchema | undefined,
+		B extends ObjectSchema | undefined
 	>(
 		changes: Partial<ProcedureArgs<P, Q, B, Errors> & {
 			keys?: ProcedureFn<Ctx, Params, Query, Body, string[], Errors>
@@ -197,7 +197,7 @@ export class ProcedureBuilder<
 	 * Adds or merges route parameter definitions to the procedure.
 	 * @param params - The TypeBox schema defining the route parameters
 	 */
-	public params = <T extends TObject>(params: SafeTObject<T, Params>) => {
+	public params = <T extends ObjectSchema>(params: SafeTObject<T, Params>) => {
 		const mergedParams = merge(this._state.params, params)
 		return this._apply<MergedObject<SafeTObject<T, Params>, Params>, Query, Body>({
 			params: mergedParams
@@ -208,7 +208,7 @@ export class ProcedureBuilder<
 	 * Adds or merges query parameter definitions to the procedure.
 	 * @param query - The TypeBox schema defining the query parameters
 	 */
-	public query = <T extends TObject>(query: SafeTObject<T, Query>) => {
+	public query = <T extends ObjectSchema>(query: SafeTObject<T, Query>) => {
 		const mergedQuery = merge(this._state.query, query)
 		return this._apply<Params, MergedObject<SafeTObject<T, Query>, Query>, Body>({
 			query: mergedQuery
@@ -219,7 +219,7 @@ export class ProcedureBuilder<
 	 * Adds or merges request body definitions to the procedure.
 	 * @param body - The TypeBox schema defining the request body
 	 */
-	public body = <T extends TObject>(body: SafeTObject<T, Body>) => {
+	public body = <T extends ObjectSchema>(body: SafeTObject<T, Body>) => {
 		const mergedBody = merge(this._state.body, body)
 		return this._apply<Params, Query, MergedObject<SafeTObject<T, Body>, Body>>({
 			body: mergedBody
@@ -256,9 +256,9 @@ export class ProcedureBuilder<
  */
 export class Procedure<
 	Ctx extends Context,
-	Params extends TObject | undefined,
-	Query extends TObject | undefined,
-	Body extends TObject | undefined,
+	Params extends ObjectSchema | undefined,
+	Query extends ObjectSchema | undefined,
+	Body extends ObjectSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > {
 	/** TypeBox schema for route parameters */
@@ -323,9 +323,9 @@ export class Procedure<
  */
 export const createProcedure = <
 	Ctx extends Context,
-	Params extends TObject | undefined = undefined,
-	Query extends TObject | undefined = undefined,
-	Body extends TObject | undefined = undefined,
+	Params extends ObjectSchema | undefined = undefined,
+	Query extends ObjectSchema | undefined = undefined,
+	Body extends ObjectSchema | undefined = undefined,
 	BaseErrors extends ErrorTable = NoErrors,
 	const ConfigErrors extends ErrorTable = NoErrors
 >(name: string, base?: Procedure<Ctx, Params, Query, Body, BaseErrors>, config: Config<ConfigErrors> = {}) => new ProcedureBuilder<Ctx, Params, Query, Body, MergedErrors<BaseErrors, ConfigErrors>>({

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -292,7 +292,7 @@ export class Procedure<
  *
  * @param name - Descriptive name for the procedure (used in logs and debugging)
  * @param base - Optional base procedure to inherit from
- * @param config - Optional tracing and error configuration, merged onto the base procedure's
+ * @param config - Optional tracing and error configuration, merged on top of the base procedure's
  *
  * @example
  * ```ts
@@ -300,7 +300,7 @@ export class Procedure<
  * 	.params(Type.Object({
  * 		id: Type.String()
  * 	}))
- * 	.handler(({ params }) => ({
+ * 	.build(({ params }) => ({
  * 		user: {
  * 			id: params.id,
  * 			name: "John Doe"

--- a/src/procedure.ts
+++ b/src/procedure.ts
@@ -12,7 +12,7 @@ import type { ErrorFactory, ErrorTable, MergedErrors, NoErrors } from './error'
 
 // define a local middleware cache
 const cache = new WeakMap<Request, Map<string, any>>()
-const cacheKey = (id: string, array: string[]) => `${id}:[${array.join(',')}]`
+const cacheKey = (id: string, keys: string[]) => `${id}:${JSON.stringify(keys)}`
 
 /**
  * Configuration arguments for creating a procedure.
@@ -236,6 +236,13 @@ export class ProcedureBuilder<
 
 
 /**
+ * Brand marking procedures. Created with Symbol.for so every copy of this package shares it; an `instanceof` check
+ * would fail across copies and make createProcedure() silently treat a base procedure as config, dropping its
+ * middlewares.
+ */
+const PROCEDURE: unique symbol = Symbol.for('elysia-procedures.Procedure')
+
+/**
  * A procedure acts as a base for creating actions.
  * It predefines and handles parameters, query, body, and middlewares.
  * The procedure can be extended to create more specific procedures
@@ -248,6 +255,7 @@ export class Procedure<
 	Body extends ObjectSchema | undefined,
 	Errors extends ErrorTable = NoErrors
 > {
+	readonly [PROCEDURE] = true
 	/** TypeBox schema for route parameters */
 	params: Params
 	/** TypeBox schema for query parameters */
@@ -265,6 +273,15 @@ export class Procedure<
 		this.body = base.body
 		this.middlewares = base.middlewares
 		this.config = base.config
+	}
+
+	/**
+	 * Whether the value is a Procedure. Prefer this over `instanceof`: it also holds for procedures created by another
+	 * copy of this package.
+	 * @param value - The value to check
+	 */
+	static is(value: unknown): value is Procedure<any, any, any, any, any> {
+		return typeof value === 'object' && value !== null && (value as Record<symbol, unknown>)[PROCEDURE] === true
 	}
 
 	/**
@@ -320,7 +337,7 @@ export function createProcedure<
 	const ConfigErrors extends ErrorTable = NoErrors
 >(name: string, base?: Procedure<Ctx, Params, Query, Body, BaseErrors>, config?: Config<ConfigErrors>): ProcedureBuilder<Ctx, Params, Query, Body, MergedErrors<BaseErrors, ConfigErrors>>
 export function createProcedure(name: string, baseOrConfig?: Procedure<any, any, any, any, any> | Config<any>, config: Config<any> = {}) {
-	const base = baseOrConfig instanceof Procedure ? baseOrConfig : undefined
+	const base = Procedure.is(baseOrConfig) ? baseOrConfig : undefined
 	if (baseOrConfig && !base) config = baseOrConfig as Config<any>
 
 	return new ProcedureBuilder({

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -1,25 +1,113 @@
-// import types
-import type { Span, SpanOptions } from '@opentelemetry/api'
+// import dependencies
+import { trace as otel, SpanStatusCode } from '@opentelemetry/api'
+import { ApiError } from './error'
 
-export type TraceOptions = SpanOptions & {
-	name: string
-	op: string
+// import types
+import type { Attributes, Span, Tracer } from '@opentelemetry/api'
+
+/**
+ * The kinds of spans this package emits. `action` and `middleware` wrap one action/middleware run, `handler` the
+ * action's own handler (after its middlewares), `input` and `output` the validation around `action.run()`.
+ */
+export type SpanType = 'action' | 'middleware' | 'handler' | 'input' | 'output'
+
+/**
+ * Options for tracing procedure and action runs through OpenTelemetry.
+ */
+export type TracingOptions = {
+	/** The tracer to create spans with; default: the global provider's tracer for this package */
+	tracer?: Tracer
+	/** Which span types to emit; every type defaults to true */
+	spans?: Partial<Record<SpanType, boolean>>
+	/** Attributes added to every span */
+	attributes?: Attributes
 }
 
-export const trace = async <T>(options: TraceOptions, fn: (span?: Span) => T) => {
-	// try tracing using sentry
-	try {
-		// @ts-expect-error dynamic import of optional dependency
-		const { startSpanManual } = await import('@sentry/bun')
-		return startSpanManual(options, fn) as T
-	} catch {}
-	
-	// try tracing using opentelemetry
-	try {
-		// @ts-expect-error dynamic import of optional dependency
-		const { record } = await import('@elysiajs/opentelemetry')
-		return record(options.name, options, fn) as T
-	} catch {}
-	
-	return fn() as T
+type Tracing = {
+	tracer: Tracer
+	spans: Record<SpanType, boolean>
+	attributes: Attributes
+}
+
+/** The active tracing configuration; tracing is off until configured */
+let tracing: Tracing | undefined
+
+/**
+ * Configures tracing for every procedure and action run. Spans are created through the OpenTelemetry API, so they
+ * nest under whatever span is active: Elysia's OpenTelemetry plugin, Sentry, or any other SDK that registered the
+ * global provider. `procedures({ observability: { tracing } })` calls this for you; call it directly when running
+ * actions outside Elysia.
+ * @param options `true` for the defaults, `false` to turn tracing off
+ */
+export const configureTracing = (options: TracingOptions | boolean = true) => {
+	if (options === false) {
+		tracing = undefined
+		return
+	}
+
+	const { tracer, spans, attributes } = options === true ? {} : options
+
+	tracing = {
+		tracer: tracer ?? otel.getTracer('@luukgoossen/elysia-procedures'),
+		spans: { action: true, middleware: true, handler: true, input: true, output: true, ...spans },
+		attributes: attributes ?? {},
+	}
+}
+
+/** Marks the span for a failure: client ApiErrors are not span errors, everything else is */
+const fail = (span: Span, error: unknown) => {
+	if (error instanceof ApiError && error.status < 500) {
+		span.setAttribute('procedure.error.reason', error.reason)
+		span.setAttribute('procedure.error.status', error.status)
+		return
+	}
+
+	span.recordException(error instanceof Error ? error : String(error))
+	span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) })
+}
+
+/**
+ * Runs `fn` inside an active span of the given type, when tracing is configured and the type is enabled. The span
+ * ends when `fn` returns or its promise settles, and records the failure when it throws.
+ * @param type The kind of span
+ * @param name The span name
+ * @param attributes Attributes specific to this span
+ * @param fn The work to trace, given the span when there is one
+ */
+export const trace = <T>(type: SpanType, name: string, attributes: Attributes, fn: (span?: Span) => T): T => {
+	if (!tracing?.spans[type]) return fn()
+
+	const options = {
+		attributes: {
+			// sentry reads the operation from this attribute, other backends ignore it
+			'sentry.op': `procedure.${type}`,
+			'procedure.type': type,
+			...tracing.attributes,
+			...attributes,
+		}
+	}
+
+	return tracing.tracer.startActiveSpan(name, options, span => {
+		try {
+			const result = fn(span)
+
+			if (result instanceof Promise) {
+				return result.then(value => {
+					span.end()
+					return value
+				}, (error: unknown) => {
+					fail(span, error)
+					span.end()
+					throw error
+				}) as T
+			}
+
+			span.end()
+			return result
+		} catch (error) {
+			fail(span, error)
+			span.end()
+			throw error
+		}
+	})
 }

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -6,8 +6,9 @@ import { ApiError } from './error'
 import type { Attributes, Span, Tracer } from '@opentelemetry/api'
 
 /**
- * The kinds of spans this package emits. `action` and `middleware` wrap one action/middleware run, `handler` the
- * action's own handler (after its middlewares), `input` and `output` the validation around `action.run()`.
+ * The kinds of spans this package emits. `action` wraps one action run and `middleware` one middleware run.
+ * `handler` wraps the action's own handler, after its middlewares. `input` and `output` wrap the validation
+ * around `action.run()`.
  */
 export type SpanType = 'action' | 'middleware' | 'handler' | 'input' | 'output'
 
@@ -15,9 +16,9 @@ export type SpanType = 'action' | 'middleware' | 'handler' | 'input' | 'output'
  * Options for tracing procedure and action runs through OpenTelemetry.
  */
 export type TracingOptions = {
-	/** The tracer to create spans with; default: the global provider's tracer for this package */
+	/** The tracer to create spans with. Defaults to the global provider's tracer for this package */
 	tracer?: Tracer
-	/** Which span types to emit; every type defaults to true */
+	/** Which span types to emit. Every type defaults to true */
 	spans?: Partial<Record<SpanType, boolean>>
 	/** Attributes added to every span */
 	attributes?: Attributes
@@ -54,7 +55,7 @@ export const configureTracing = (options: TracingOptions | boolean = true) => {
 	}
 }
 
-/** Marks the span for a failure: client ApiErrors are not span errors, everything else is */
+/** Marks the span for a failure. A 4xx ApiError is an expected outcome and does not fail the span; everything else does */
 const fail = (span: Span, error: unknown) => {
 	if (error instanceof ApiError && error.status < 500) {
 		span.setAttribute('procedure.error.reason', error.reason)
@@ -68,7 +69,7 @@ const fail = (span: Span, error: unknown) => {
 
 /**
  * Runs `fn` inside an active span of the given type, when tracing is configured and the type is enabled. The span
- * ends when `fn` returns or its promise settles, and records the failure when it throws.
+ * ends when `fn` returns or its promise settles, and records the failure if it throws.
  * @param type The kind of span
  * @param name The span name
  * @param attributes Attributes specific to this span

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -57,7 +57,7 @@ export const configureTracing = (options: TracingOptions | boolean = true) => {
 
 /** Marks the span for a failure. A 4xx ApiError is an expected outcome and does not fail the span; everything else does */
 const fail = (span: Span, error: unknown) => {
-	if (error instanceof ApiError && error.status < 500) {
+	if (ApiError.is(error) && error.status < 500) {
 		span.setAttribute('procedure.error.reason', error.reason)
 		span.setAttribute('procedure.error.status', error.status)
 		return

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,8 +44,8 @@ export const merge = <
  */
 export type Context = {
 	/** The received HTTP request */
-	request: Request;
-	cookie: Record<string, Cookie<unknown>>;
+	request: Request
+	cookie: Record<string, Cookie<unknown>>
 }
 
 /**
@@ -55,23 +55,22 @@ export type Context = {
  * schema's `static` type (TypeBox's `ObjectStatic`) on every check. Checking against this alias only compares `type`
  * and `properties`, around forty times cheaper, and still rejects non-object schemas. Any `TObject<...>` satisfies it.
  */
-export type ObjectSchema = TSchema & { type: 'object'; properties: TProperties }
+export type ObjectSchema = TSchema & { type: 'object', properties: TProperties }
 
 /**
  * API documentation details for an action or procedure.
  */
-export type Decorations<Errors extends ErrorTable = ErrorTable> =
-  DocumentDecoration & Config<Errors>
+export type Decorations<Errors extends ErrorTable = ErrorTable> = DocumentDecoration & Config<Errors>
 
 /**
  * Tracing and error configuration for an action or procedure.
  */
 export type Config<Errors extends ErrorTable = ErrorTable> = {
 	tracing?: {
-		name?: string;
-		attributes?: Attributes;
-	};
-	errors?: ErrorConfig<Errors>;
+		name?: string
+		attributes?: Attributes
+	}
+	errors?: ErrorConfig<Errors>
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,11 +49,11 @@ export type Context = {
 }
 
 /**
- * Structural stand-in for `TObject` used in generic constraints and conditional types.
+ * Structural stand-in for `TObject` in generic constraints and conditional types.
  *
- * Relating a schema to `TObject` itself makes TypeScript compare the two structurally, which evaluates the schema's
- * `static` type (TypeBox's `ObjectStatic`) for every check. Relating it to this alias only compares `type` and `properties`,
- * which is around forty times cheaper while still rejecting non-object schemas. Any `TObject<...>` satisfies it.
+ * Checking a schema against `TObject` itself makes TypeScript compare the two structurally, which evaluates the
+ * schema's `static` type (TypeBox's `ObjectStatic`) on every check. Checking against this alias only compares `type`
+ * and `properties`, around forty times cheaper, and still rejects non-object schemas. Any `TObject<...>` satisfies it.
  */
 export type ObjectSchema = TSchema & { type: 'object'; properties: TProperties }
 
@@ -75,7 +75,7 @@ export type Config<Errors extends ErrorTable = ErrorTable> = {
 }
 
 /**
- * A utility type that ensures an object schema (Next) does not have any overlapping properties with an optional reference schema (Prev).
+ * Resolves to Next when its properties do not overlap with those of the optional Prev schema, and to never otherwise.
  */
 export type SafeTObject<
 	Next extends ObjectSchema,
@@ -87,9 +87,9 @@ export type SafeTObject<
 	: Next
 
 /**
- * A utility type that merges two object schemas into one.
+ * Merges two object schemas into one.
  * Without a previous schema the next schema is returned as is, so no new type is created.
- * Overlapping properties are rejected by `SafeTObject`, so a plain intersection of the properties is exact.
+ * `SafeTObject` already rejects overlapping properties, so a plain intersection of the properties is exact.
  */
 export type MergedObject<
 	Next extends ObjectSchema,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,11 +6,14 @@ import type { DocumentDecoration } from 'elysia'
 import type { TObject } from '@sinclair/typebox'
 import type { Merge, Simplify } from 'type-fest'
 import type { Cookie } from 'elysia'
+import type { ErrorConfig, ErrorTable } from './error'
 
 /** Converts a string from Title Case to camelCase */
 export const toCamelCase = (str: string): string =>
 	str
-		.replace(/(?:^\w|[A-Z]|\b\w)/g, (match, index) => index === 0 ? match.toLowerCase() : match.toUpperCase())
+		.replace(/(?:^\w|[A-Z]|\b\w)/g, (match, index) =>
+			index === 0 ? match.toLowerCase() : match.toUpperCase(),
+		)
 		.replace(/\s+/g, '')
 
 /**
@@ -23,55 +26,71 @@ export const toCamelCase = (str: string): string =>
 export const merge = <
 	Prev extends TObject | undefined,
 	Next extends TObject | never,
->(prev: Prev, next: Next): MergedObject<Next, Prev> =>
-	Type.Object({
-		...next.properties,
-		...(prev ? prev.properties : {}),
-	}, { additionalProperties: false }) as any
+>(
+	prev: Prev,
+	next: Next,
+): MergedObject<Next, Prev> =>
+	Type.Object(
+		{
+			...next.properties,
+			...(prev ? prev.properties : {}),
+		},
+		{ additionalProperties: false },
+	) as any
 
 /**
  * Base context available in all procedures.
  */
 export type Context = {
 	/** The received HTTP request */
-	request: Request
-	cookie: Record<string, Cookie<unknown>>
+	request: Request;
+	cookie: Record<string, Cookie<unknown>>;
 }
 
 /**
  * API documentation details for an action or procedure.
  */
-export type Decorations = DocumentDecoration & Config
+export type Decorations<Errors extends ErrorTable = ErrorTable> =
+  DocumentDecoration & Config<Errors>
 
 /**
- * Tracing configuration for an action or procedure.
+ * Tracing and error configuration for an action or procedure.
  */
-export type Config = {
+export type Config<Errors extends ErrorTable = ErrorTable> = {
 	tracing?: {
-		name?: string
-		attributes?: Record<string, unknown>
-	}
+		name?: string;
+		attributes?: Record<string, unknown>;
+	};
+	errors?: ErrorConfig<Errors>;
 }
 
 /**
  * A utlity type that ensures a TObject (Next) does not have any overlapping properties with an opional reference TObject (Prev).
  */
-export type SafeTObject<Next extends TObject, Prev extends TObject | undefined = undefined> = Prev extends TObject
-	? (Extract<keyof Prev['properties'], keyof Next['properties']> extends never
+export type SafeTObject<
+	Next extends TObject,
+	Prev extends TObject | undefined = undefined,
+> = Prev extends TObject
+	? Extract<keyof Prev['properties'], keyof Next['properties']> extends never
 		? Next
-		: never)
+		: never
 	: Next
 
 /**
  * A utility type that checks the properties of a TypeBox object schema.
  */
-export type CheckProperties<T extends TObject | undefined> = T extends TObject ? T['properties'] : unknown
+export type CheckProperties<T extends TObject | undefined> = T extends TObject
+	? T['properties']
+	: unknown
 
 /**
  * A utility type that merges the properties of two TypeBox object schemas.
  * The second schema is optional and can be undefined.
  */
-export type MergedProperties<Next extends TObject, Prev extends TObject | undefined = undefined> = Merge<Next['properties'], CheckProperties<Prev>>
+export type MergedProperties<
+	Next extends TObject,
+	Prev extends TObject | undefined = undefined,
+> = Merge<Next['properties'], CheckProperties<Prev>>
 
 /**
  * A utility type that merges two TypeBox objects into one.
@@ -88,4 +107,7 @@ export type MergedObject<
  * A utility type that merges the context of a procedure with an optional next context.
  * The next context can be an object or void.
  */
-export type MergedContext<Ctx extends Context, Next extends object | void = void> = Simplify<Context & Merge<Ctx, Next extends object ? Next : unknown>>
+export type MergedContext<
+	Ctx extends Context,
+	Next extends object | void = void,
+> = Simplify<Context & Merge<Ctx, Next extends object ? Next : unknown>>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,8 @@ import { Type } from '@sinclair/typebox'
 import type { DocumentDecoration } from 'elysia'
 
 // import types
-import type { TObject } from '@sinclair/typebox'
-import type { Merge, Simplify } from 'type-fest'
+import type { TObject, TProperties, TSchema } from '@sinclair/typebox'
+import type { Simplify } from 'type-fest'
 import type { Cookie } from 'elysia'
 import type { ErrorConfig, ErrorTable } from './error'
 
@@ -24,8 +24,8 @@ export const toCamelCase = (str: string): string =>
  * @returns A new object schema that combines properties from both schemas.
  */
 export const merge = <
-	Prev extends TObject | undefined,
-	Next extends TObject | never,
+	Prev extends ObjectSchema | undefined,
+	Next extends ObjectSchema,
 >(
 	prev: Prev,
 	next: Next,
@@ -48,6 +48,15 @@ export type Context = {
 }
 
 /**
+ * Structural stand-in for `TObject` used in generic constraints and conditional types.
+ *
+ * Relating a schema to `TObject` itself makes TypeScript compare the two structurally, which evaluates the schema's
+ * `static` type (TypeBox's `ObjectStatic`) for every check. Relating it to this alias only compares `type` and `properties`,
+ * which is around forty times cheaper while still rejecting non-object schemas. Any `TObject<...>` satisfies it.
+ */
+export type ObjectSchema = TSchema & { type: 'object'; properties: TProperties }
+
+/**
  * API documentation details for an action or procedure.
  */
 export type Decorations<Errors extends ErrorTable = ErrorTable> =
@@ -65,43 +74,30 @@ export type Config<Errors extends ErrorTable = ErrorTable> = {
 }
 
 /**
- * A utlity type that ensures a TObject (Next) does not have any overlapping properties with an opional reference TObject (Prev).
+ * A utility type that ensures an object schema (Next) does not have any overlapping properties with an optional reference schema (Prev).
  */
 export type SafeTObject<
-	Next extends TObject,
-	Prev extends TObject | undefined = undefined,
-> = Prev extends TObject
+	Next extends ObjectSchema,
+	Prev extends ObjectSchema | undefined = undefined,
+> = Prev extends ObjectSchema
 	? Extract<keyof Prev['properties'], keyof Next['properties']> extends never
 		? Next
 		: never
 	: Next
 
 /**
- * A utility type that checks the properties of a TypeBox object schema.
- */
-export type CheckProperties<T extends TObject | undefined> = T extends TObject
-	? T['properties']
-	: unknown
-
-/**
- * A utility type that merges the properties of two TypeBox object schemas.
- * The second schema is optional and can be undefined.
- */
-export type MergedProperties<
-	Next extends TObject,
-	Prev extends TObject | undefined = undefined,
-> = Merge<Next['properties'], CheckProperties<Prev>>
-
-/**
- * A utility type that merges two TypeBox objects into one.
- * The next schema's properties will override the previous schema's properties.
+ * A utility type that merges two object schemas into one.
+ * Without a previous schema the next schema is returned as is, so no new type is created.
+ * Overlapping properties are rejected by `SafeTObject`, so a plain intersection of the properties is exact.
  */
 export type MergedObject<
-	Next extends TObject | never,
-	Prev extends TObject | undefined = undefined,
-> = Next extends TObject
-	? TObject<Simplify<MergedProperties<Next, Prev>>>
-	: Prev
+	Next extends ObjectSchema,
+	Prev extends ObjectSchema | undefined = undefined,
+> = Next extends ObjectSchema
+	? Prev extends ObjectSchema
+		? TObject<Simplify<Next['properties'] & Prev['properties']>>
+		: Next
+	: never
 
 /**
  * A utility type that merges the context of a procedure with an optional next context.
@@ -110,4 +106,4 @@ export type MergedObject<
 export type MergedContext<
 	Ctx extends Context,
 	Next extends object | void = void,
-> = Simplify<Context & Merge<Ctx, Next extends object ? Next : unknown>>
+> = [Next] extends [object] ? Simplify<Context & Omit<Ctx, keyof Next> & Next> : Ctx

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 // import dependencies
 import { Type } from '@sinclair/typebox'
 import type { DocumentDecoration } from 'elysia'
+import type { Attributes } from '@opentelemetry/api'
 
 // import types
 import type { TObject, TProperties, TSchema } from '@sinclair/typebox'
@@ -68,7 +69,7 @@ export type Decorations<Errors extends ErrorTable = ErrorTable> =
 export type Config<Errors extends ErrorTable = ErrorTable> = {
 	tracing?: {
 		name?: string;
-		attributes?: Record<string, unknown>;
+		attributes?: Attributes;
 	};
 	errors?: ErrorConfig<Errors>;
 }

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -17,7 +17,7 @@ describe('Action Builder', () => {
 		const details = { description: 'Test action description' }
 		const action = procedure.createAction('Test Action', details).build(() => { })
 
-		expect(action.details).toEqual(details)
+		expect(action.details).toEqual({ ...details, errors: { table: {} } })
 	})
 
 	test('should create action with OpenAPI documentation', () => {

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -52,6 +52,18 @@ describe('ApiError', () => {
 	})
 })
 
+describe('ApiError.is', () => {
+	test('recognizes errors by brand rather than prototype', () => {
+		const error = new ApiError({ status: 404, reason: 'NOT_FOUND', metadata: undefined, title: 'Not found', type: 'about:blank' })
+		const foreign = Object.assign(new Error('Not found'), { status: 404, [Symbol.for('elysia-procedures.ApiError')]: true })
+
+		expect(ApiError.is(error)).toBe(true)
+		expect(ApiError.is(foreign)).toBe(true)
+		expect(ApiError.is(new Error('Not found'))).toBe(false)
+		expect(ApiError.is(undefined)).toBe(false)
+	})
+})
+
 describe('mergeErrors', () => {
 	test('child keys win and type is inherited', () => {
 		const parent = { type: (r: string) => `/p/${r}`, table: { A: { status: 400, title: 'parent' }, B: { status: 401 } } }

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,0 +1,142 @@
+// import dependencies
+import { describe, test, expect } from 'bun:test'
+import { Type } from '@sinclair/typebox'
+import { ApiError, DEFAULT_ERRORS, createErrorFactory, mergeErrors, statusesOf } from '@/error'
+
+const table = {
+	NOT_FOUND: {
+		status: 404,
+		metadata: Type.Object({ entity: Type.String() }),
+		title: (m: { entity: string }) => `${m.entity} not found`,
+		detail: 'The requested resource does not exist.'
+	},
+	FORBIDDEN: { status: 403, title: 'Forbidden' },
+	RATE_LIMITED: { status: 429 },
+	UPSTREAM_DOWN: { status: 502, title: 'Upstream down' },
+}
+
+describe('ApiError', () => {
+	test('serializes to an RFC 9457 problem without cause', () => {
+		const error = new ApiError({
+			status: 404,
+			reason: 'NOT_FOUND',
+			metadata: { entity: 'Video' },
+			title: 'Video not found',
+			detail: 'Gone',
+			type: '/errors/NOT_FOUND',
+			cause: new Error('secret')
+		})
+
+		expect(error).toBeInstanceOf(Error)
+		expect(error.cause).toBeInstanceOf(Error)
+		expect(error.message).toBe('Video not found')
+
+		const problem = error.toProblem({ instance: '/videos/1', reference: 'ref' })
+		expect(problem).toEqual({
+			type: '/errors/NOT_FOUND',
+			title: 'Video not found',
+			status: 404,
+			detail: 'Gone',
+			instance: '/videos/1',
+			reason: 'NOT_FOUND',
+			metadata: { entity: 'Video' },
+			reference: 'ref'
+		})
+		expect(JSON.stringify(problem)).not.toContain('secret')
+		expect('cause' in problem).toBe(false)
+	})
+
+	test('omits undefined members', () => {
+		const error = new ApiError({ status: 500, reason: 'INTERNAL', metadata: undefined, title: 'Oops', type: 'about:blank' })
+		expect(Object.keys(error.toProblem())).toEqual(['type', 'title', 'status', 'reason'])
+	})
+})
+
+describe('mergeErrors', () => {
+	test('child keys win and type is inherited', () => {
+		const parent = { type: (r: string) => `/p/${r}`, table: { A: { status: 400, title: 'parent' }, B: { status: 401 } } }
+		const child = { table: { A: { status: 409, title: 'child' }, C: { status: 403 } } }
+		const merged = mergeErrors(parent, child)
+
+		expect(merged.table).toEqual({ A: { status: 409, title: 'child' }, B: { status: 401 }, C: { status: 403 } })
+		expect(merged.type?.('A')).toBe('/p/A')
+	})
+
+	test('child type overrides parent type', () => {
+		const merged = mergeErrors({ type: () => 'parent' }, { type: () => 'child' })
+		expect(merged.type?.('X')).toBe('child')
+	})
+
+	test('handles undefined on either side', () => {
+		expect(mergeErrors(undefined, undefined)).toEqual({ table: {} })
+		expect(mergeErrors(undefined, { table: { A: { status: 400 } } }).table).toEqual({ A: { status: 400 } })
+	})
+})
+
+describe('statusesOf', () => {
+	test('returns unique sorted statuses including the package defaults', () => {
+		expect(statusesOf({ A: { status: 404 }, B: { status: 404 }, C: { status: 403 } })).toEqual([400, 403, 404, 422, 500])
+	})
+})
+
+describe('createErrorFactory', () => {
+	const onError = createErrorFactory({ table, type: r => `/errors/${r}` })
+
+	test('resolves title from entry function and detail from entry string', () => {
+		const error = onError('NOT_FOUND', { entity: 'Video' })
+		expect(error).toBeInstanceOf(ApiError)
+		expect(error.status).toBe(404)
+		expect(error.reason).toBe('NOT_FOUND')
+		expect(error.metadata).toEqual({ entity: 'Video' })
+		expect(error.title).toBe('Video not found')
+		expect(error.detail).toBe('The requested resource does not exist.')
+		expect(error.type).toBe('/errors/NOT_FOUND')
+	})
+
+	test('options take precedence over entry copy', () => {
+		const cause = new Error('x')
+		const error = onError('NOT_FOUND', { entity: 'Video' }, { title: 'Custom', detail: 'Custom detail', cause })
+		expect(error.title).toBe('Custom')
+		expect(error.detail).toBe('Custom detail')
+		expect(error.cause).toBe(cause)
+	})
+
+	test('falls back to a title cased reason and no detail', () => {
+		const error = onError('RATE_LIMITED')
+		expect(error.title).toBe('Rate Limited')
+		expect(error.detail).toBeUndefined()
+		expect(error.metadata).toBeUndefined()
+	})
+
+	test('throws a TypeError on invalid metadata or unknown reason', () => {
+		expect(() => (onError as any)('NOT_FOUND', { entity: 1 })).toThrow(TypeError)
+		expect(() => (onError as any)('NOPE')).toThrow(TypeError)
+	})
+
+	test('uses about:blank when no type function is given', () => {
+		expect(createErrorFactory({ table })('FORBIDDEN').type).toBe('about:blank')
+	})
+
+	test('unexpected wraps a cause as a 500 with default copy', () => {
+		const cause = new Error('db exploded')
+		const error = createErrorFactory({ table }).unexpected(cause)
+		expect(error.status).toBe(500)
+		expect(error.reason).toBe('INTERNAL')
+		expect(error.title).toBe(DEFAULT_ERRORS.INTERNAL.title)
+		expect(error.cause).toBe(cause)
+		expect(JSON.stringify(error.toProblem())).not.toContain('db exploded')
+	})
+
+	test('unexpected accepts an alternative reason with status >= 500', () => {
+		const factory = createErrorFactory({ table })
+		expect(factory.unexpected(new Error('x'), { reason: 'UPSTREAM_DOWN' }).status).toBe(502)
+		expect(() => factory.unexpected(new Error('x'), { reason: 'FORBIDDEN' })).toThrow(TypeError)
+	})
+
+	test('package defaults are callable and overridable by key', () => {
+		expect(createErrorFactory({ table })('INVALID_INPUT').status).toBe(422)
+		const overridden = createErrorFactory({ table: { INTERNAL: { status: 503, title: 'Down' } } })
+		expect(overridden('INTERNAL').status).toBe(503)
+		expect(overridden.unexpected(new Error('x')).title).toBe('Down')
+	})
+})

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -3,7 +3,8 @@ import { describe, test, expect, mock, beforeEach } from 'bun:test'
 import { Elysia, t } from 'elysia'
 import { openapi } from '@elysiajs/openapi'
 import { createProcedure } from '@/procedure'
-import { problems } from '@/problems'
+import { resolveProblem, problemResponse } from '@/problems'
+import { procedures, procedureModels, sentryReporter } from '@/plugin'
 import { ApiError } from '@/error'
 
 // mock the optional sentry dependency
@@ -44,8 +45,8 @@ const create = base.createAction('Create Video').body(t.Object({
 })).build(({ body }) => body)
 const boom = base.createAction('Boom').build(() => { throw new Error('db exploded') })
 
-const build = (options?: Parameters<typeof problems>[0]) => new Elysia()
-	.use(problems({ log, ...options }))
+const build = (options?: Parameters<typeof procedures>[0]) => new Elysia()
+	.use(procedures({ ...options, observability: { logging: log, ...options?.observability } }))
 	.get('/videos/:id', notFound.handle, notFound.docs)
 	.get('/upstream', upstream.handle, upstream.docs)
 	.get('/wrapped', wrapped.handle, wrapped.docs)
@@ -62,7 +63,7 @@ beforeEach(() => {
 	captureMessage.mockClear()
 })
 
-describe('problems() plugin', () => {
+describe('procedures() plugin', () => {
 	test('serializes a 4xx ApiError without reporting', async () => {
 		const res = await request(build(), '/videos/abc')
 
@@ -133,7 +134,7 @@ describe('problems() plugin', () => {
 	})
 
 	test('elides sensitive received values and truncates long ones', async () => {
-		const res = await request(build({ receivedMaxLength: 10 }), '/videos', {
+		const res = await request(build({ errors: { receivedMaxLength: 10 } }), '/videos', {
 			method: 'POST',
 			headers: { 'content-type': 'application/json' },
 			body: JSON.stringify({ name: 'x'.repeat(50), password: 'short', tags: [1] })
@@ -147,7 +148,7 @@ describe('problems() plugin', () => {
 	})
 
 	test('omits received for missing properties and maps locations', async () => {
-		const app = new Elysia().use(problems({ log })).get('/q', () => 'ok', { query: t.Object({ page: t.Number() }) })
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).get('/q', () => 'ok', { query: t.Object({ page: t.Number() }) })
 		const res = await request(app, '/q')
 		const body: any = await res.json()
 
@@ -160,7 +161,7 @@ describe('problems() plugin', () => {
 	})
 
 	test('treats response validation failures as server errors', async () => {
-		const app = new Elysia().use(problems({ log })).get('/r', () => ({ id: 1 }) as any, { response: t.Object({ id: t.String() }) })
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).get('/r', () => ({ id: 1 }) as any, { response: t.Object({ id: t.String() }) })
 		const res = await request(app, '/r')
 		const body: any = await res.json()
 
@@ -224,21 +225,21 @@ describe('problems() plugin', () => {
 	})
 
 	test('captureClientErrors reports 4xx ApiErrors as messages', async () => {
-		await request(build({ captureClientErrors: 'warn' }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'warn' }) } }), '/videos/abc')
 		expect(captureMessage).toHaveBeenCalledTimes(1)
 		expect(captureMessage.mock.calls[0] as unknown[]).toEqual(['Video not found', { level: 'warning', tags: { reason: 'NOT_FOUND', status: 404 } }])
 
-		await request(build({ captureClientErrors: 'all' }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'all' }) } }), '/videos/abc')
 		expect((captureMessage.mock.calls[1] as unknown[])[1]).toMatchObject({ level: 'info' })
 
-		await request(build({ captureClientErrors: 'off' }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'off' }) } }), '/videos/abc')
 		expect(captureMessage).toHaveBeenCalledTimes(2)
 	})
 
 	test('covers nested sub-apps when mounted once on the root', async () => {
 		const leaf = new Elysia({ prefix: '/leaf' }).get('/boom', boom.handle, boom.docs).get('/video/:id', notFound.handle, notFound.docs)
 		const branch = new Elysia({ prefix: '/branch' }).use(leaf)
-		const app = new Elysia().use(problems({ log })).use(branch)
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).use(branch)
 
 		const res = await request(app, '/branch/leaf/boom')
 		expect(res.status).toBe(500)
@@ -251,8 +252,8 @@ describe('problems() plugin', () => {
 	})
 
 	test('handles each error once when mounted on several instances', async () => {
-		const child = new Elysia().use(problems({ log })).get('/child', () => { throw new Error('x') })
-		const app = new Elysia().use(problems({ log })).use(child)
+		const child = new Elysia().use(procedures({ observability: { logging: log } })).get('/child', () => { throw new Error('x') })
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).use(child)
 
 		const res = await request(app, '/child')
 		expect(res.status).toBe(500)
@@ -261,11 +262,65 @@ describe('problems() plugin', () => {
 
 	test('does not cover sub-apps mounted before it', async () => {
 		const child = new Elysia().get('/child', () => { throw new Error('x') })
-		const app = new Elysia().use(child).use(problems({ log }))
+		const app = new Elysia().use(child).use(procedures({ observability: { logging: log } }))
 
 		const res = await request(app, '/child')
 		expect(res.status).toBe(500)
 		expect(res.headers.get('content-type')).not.toBe('application/problem+json')
+	})
+})
+
+describe('bring your own handler', () => {
+	test('a custom reporter replaces the sentry policy', async () => {
+		const seen: unknown[] = []
+		const report = mock((error: unknown) => { seen.push(error); return 'custom-ref' })
+		const res = await request(build({ observability: { errorReporting: report } }), '/boom')
+
+		expect(((await res.json()) as any).reference).toBe('custom-ref')
+		expect(seen[0]).toBeInstanceOf(Error)
+		expect(captureException).not.toHaveBeenCalled()
+
+		const silent = await request(build({ observability: { errorReporting: () => undefined } }), '/boom')
+		expect(((await silent.json()) as any).reference).toBeUndefined()
+	})
+
+	test('resolveProblem is pure and mirrors the plugin', () => {
+		const apiError = new ApiError({ status: 404, reason: 'NOT_FOUND', metadata: undefined, title: 'Gone', type: 'about:blank' })
+		expect(resolveProblem('API_ERROR', apiError, { instance: '/x' })).toEqual({ type: 'about:blank', title: 'Gone', status: 404, instance: '/x', reason: 'NOT_FOUND' })
+		expect(resolveProblem('NOT_FOUND', new Error('x'), { errors: { type: r => `/e/${r}` } })).toMatchObject({ type: '/e/NOT_FOUND', status: 404 })
+		expect(resolveProblem('UNKNOWN', new Error('db exploded'))).toEqual({ type: 'about:blank', title: 'Something went wrong', status: 500, reason: 'INTERNAL', detail: expect.any(String) })
+		expect(JSON.stringify(resolveProblem('UNKNOWN', new Error('db exploded')))).not.toContain('db exploded')
+		expect(resolveProblem(302, new Response(null, { status: 302 }))).toBeUndefined()
+		expect(captureException).not.toHaveBeenCalled()
+	})
+
+	test('problemResponse serializes with the problem media type', async () => {
+		const res = problemResponse({ type: 'about:blank', title: 'Nope', status: 418, reason: 'TEAPOT' })
+		expect(res.status).toBe(418)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(await res.json()).toMatchObject({ reason: 'TEAPOT' })
+	})
+
+	test('procedureModels plus a custom onError keeps docs and the contract', async () => {
+		const app = new Elysia()
+			.use(procedureModels())
+			.onError(({ code, error, request }) => {
+				const problem = resolveProblem(code, error, { instance: new URL(request.url).pathname })
+				if (!problem) return
+				return problemResponse({ ...problem, reference: 'mine' })
+			})
+			.use(openapi())
+			.get('/videos/:id', notFound.handle, notFound.docs)
+
+		const res = await request(app, '/videos/abc')
+		expect(res.status).toBe(404)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(await res.json()).toMatchObject({ reason: 'NOT_FOUND', metadata: { entity: 'Video' }, reference: 'mine' })
+
+		const spec: any = await (await request(app, '/openapi/json')).json()
+		expect(spec.components.schemas.Problem).toBeDefined()
+		expect(spec.paths['/videos/{id}'].get.responses['404'].content['application/json'].schema).toEqual({ $ref: '#/components/schemas/Problem' })
+		expect(captureException).not.toHaveBeenCalled()
 	})
 })
 
@@ -295,7 +350,7 @@ describe('openapi integration', () => {
 describe('elysia built-in errors', () => {
 	test('maps invalid file types to 422', async () => {
 		const app = new Elysia()
-			.use(problems({ log }))
+			.use(procedures({ observability: { logging: log } }))
 			.post('/upload', () => 'ok', { body: t.Object({ file: t.File({ type: 'image/png' }) }) })
 
 		const form = new FormData()
@@ -320,9 +375,9 @@ describe('sub-apps', () => {
 			.output(t.Object({ ok: t.Boolean() }))
 			.build(({ body }, onError) => { if (body.name === 'x') throw onError('NOPE'); return { ok: true } })
 
-		const g1 = new Elysia({ prefix: '/g1' }).use(problems({ log })).post('/a', action.handle, action.docs)
-		const g2 = new Elysia({ prefix: '/g2' }).use(problems({ log })).post('/a', action.handle, action.docs)
-		const app = new Elysia().use(problems({ log })).use(g1).use(g2)
+		const g1 = new Elysia({ prefix: '/g1' }).use(procedures({ observability: { logging: log } })).post('/a', action.handle, action.docs)
+		const g2 = new Elysia({ prefix: '/g2' }).use(procedures({ observability: { logging: log } })).post('/a', action.handle, action.docs)
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).use(g1).use(g2)
 
 		const res = await app.handle(new Request('http://localhost/g2/a', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: 'x' }) }))
 		expect(res.status).toBe(418)

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -7,14 +7,10 @@ import { resolveProblem, problemResponse } from '@/problems'
 import { procedures, procedureModels, sentryReporter } from '@/plugin'
 import { ApiError } from '@/error'
 
-// mock the optional sentry dependency
+// a stand-in for a sentry sdk
 const captureException = mock(() => 'event-id-exception')
 const captureMessage = mock(() => 'event-id-message')
-mock.module('@sentry/bun', () => ({
-	captureException,
-	captureMessage,
-	startSpanManual: (_options: unknown, fn: (span?: unknown) => unknown) => fn(),
-}))
+const Sentry = { captureException, captureMessage }
 
 const logs: { level: string; fields: Record<string, unknown> }[] = []
 const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => { logs.push({ level, fields }) }
@@ -46,7 +42,7 @@ const create = base.createAction('Create Video').body(t.Object({
 const boom = base.createAction('Boom').build(() => { throw new Error('db exploded') })
 
 const build = (options?: Parameters<typeof procedures>[0]) => new Elysia()
-	.use(procedures({ ...options, observability: { logging: log, ...options?.observability } }))
+	.use(procedures({ ...options, observability: { logging: log, errorReporting: sentryReporter(Sentry), ...options?.observability } }))
 	.get('/videos/:id', notFound.handle, notFound.docs)
 	.get('/upstream', upstream.handle, upstream.docs)
 	.get('/wrapped', wrapped.handle, wrapped.docs)
@@ -161,7 +157,7 @@ describe('procedures() plugin', () => {
 	})
 
 	test('treats response validation failures as server errors', async () => {
-		const app = new Elysia().use(procedures({ observability: { logging: log } })).get('/r', () => ({ id: 1 }) as any, { response: t.Object({ id: t.String() }) })
+		const app = new Elysia().use(procedures({ observability: { logging: log, errorReporting: sentryReporter(Sentry) } })).get('/r', () => ({ id: 1 }) as any, { response: t.Object({ id: t.String() }) })
 		const res = await request(app, '/r')
 		const body: any = await res.json()
 
@@ -225,14 +221,14 @@ describe('procedures() plugin', () => {
 	})
 
 	test('captureClientErrors reports 4xx ApiErrors as messages', async () => {
-		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'warn' }) } }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter(Sentry, { captureClientErrors: 'warn' }) } }), '/videos/abc')
 		expect(captureMessage).toHaveBeenCalledTimes(1)
 		expect(captureMessage.mock.calls[0] as unknown[]).toEqual(['Video not found', { level: 'warning', tags: { reason: 'NOT_FOUND', status: 404 } }])
 
-		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'all' }) } }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter(Sentry, { captureClientErrors: 'all' }) } }), '/videos/abc')
 		expect((captureMessage.mock.calls[1] as unknown[])[1]).toMatchObject({ level: 'info' })
 
-		await request(build({ observability: { errorReporting: sentryReporter({ captureClientErrors: 'off' }) } }), '/videos/abc')
+		await request(build({ observability: { errorReporting: sentryReporter(Sentry, { captureClientErrors: 'off' }) } }), '/videos/abc')
 		expect(captureMessage).toHaveBeenCalledTimes(2)
 	})
 
@@ -271,6 +267,16 @@ describe('procedures() plugin', () => {
 })
 
 describe('bring your own handler', () => {
+	test('reports nothing and yields no reference without a reporter', async () => {
+		const app = new Elysia().use(procedures({ observability: { logging: log } })).get('/boom', boom.handle, boom.docs)
+		const res = await request(app, '/boom')
+
+		expect(res.status).toBe(500)
+		expect(((await res.json()) as any).reference).toBeUndefined()
+		expect(captureException).not.toHaveBeenCalled()
+		expect(logs[0]?.fields).not.toHaveProperty('reference')
+	})
+
 	test('a custom reporter replaces the sentry policy', async () => {
 		const seen: unknown[] = []
 		const report = mock((error: unknown) => { seen.push(error); return 'custom-ref' })

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -12,7 +12,7 @@ const captureException = mock(() => 'event-id-exception')
 const captureMessage = mock(() => 'event-id-message')
 const Sentry = { captureException, captureMessage }
 
-const logs: { level: string; fields: Record<string, unknown> }[] = []
+const logs: { level: string, fields: Record<string, unknown> }[] = []
 const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => { logs.push({ level, fields }) }
 
 const base = createProcedure('Base', {
@@ -141,6 +141,34 @@ describe('procedures() plugin', () => {
 		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/password').received).toBeUndefined()
 		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/tags/0').received).toBe('1')
 		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/name')).toBeUndefined()
+	})
+
+	test('redacts sensitive properties nested inside an echoed object', async () => {
+		const app = new Elysia()
+			.use(procedures({ observability: { logging: log } }))
+			.post('/login', () => 'ok', {
+				body: t.Object({
+					credentials: t.Union([
+						t.Object({ username: t.String(), password: t.String() }),
+						t.Object({ apiToken: t.String() }),
+					]),
+				}),
+			})
+
+		const res = await request(app, '/login', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ credentials: { username: 'luuk', password: 12345678, nested: { secretKey: 's3', ok: 1 } } }),
+		})
+		const body = await res.json() as { errors: { pointer: string, received?: string }[] }
+
+		expect(res.status).toBe(422)
+		const field = body.errors.find(e => e.pointer === '#/credentials')
+		expect(field?.received).toContain('"username":"luuk"')
+		expect(field?.received).toContain('"password":"[redacted]"')
+		expect(field?.received).toContain('"secretKey":"[redacted]"')
+		expect(field?.received).not.toContain('12345678')
+		expect(field?.received).not.toContain('s3')
 	})
 
 	test('omits received for missing properties and maps locations', async () => {

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -235,14 +235,37 @@ describe('problems() plugin', () => {
 		expect(captureMessage).toHaveBeenCalledTimes(2)
 	})
 
-	test('is idempotent when used on multiple instances', async () => {
+	test('covers nested sub-apps when mounted once on the root', async () => {
+		const leaf = new Elysia({ prefix: '/leaf' }).get('/boom', boom.handle, boom.docs).get('/video/:id', notFound.handle, notFound.docs)
+		const branch = new Elysia({ prefix: '/branch' }).use(leaf)
+		const app = new Elysia().use(problems({ log })).use(branch)
+
+		const res = await request(app, '/branch/leaf/boom')
+		expect(res.status).toBe(500)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+
+		const res2 = await request(app, '/branch/leaf/video/abc')
+		expect(res2.status).toBe(404)
+		expect(await res2.json()).toMatchObject({ reason: 'NOT_FOUND', metadata: { entity: 'Video' } })
+		expect(logs).toHaveLength(2)
+	})
+
+	test('handles each error once when mounted on several instances', async () => {
 		const child = new Elysia().use(problems({ log })).get('/child', () => { throw new Error('x') })
 		const app = new Elysia().use(problems({ log })).use(child)
 
 		const res = await request(app, '/child')
 		expect(res.status).toBe(500)
-		expect(res.headers.get('content-type')).toBe('application/problem+json')
 		expect(logs).toHaveLength(1)
+	})
+
+	test('does not cover sub-apps mounted before it', async () => {
+		const child = new Elysia().get('/child', () => { throw new Error('x') })
+		const app = new Elysia().use(child).use(problems({ log }))
+
+		const res = await request(app, '/child')
+		expect(res.status).toBe(500)
+		expect(res.headers.get('content-type')).not.toBe('application/problem+json')
 	})
 })
 

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -286,3 +286,29 @@ describe('elysia built-in errors', () => {
 		expect(body.detail).toBe('1 field is invalid: body.file')
 	})
 })
+
+describe('sub-apps', () => {
+	test('handles each error once when mounted on nested sub-apps', async () => {
+		const calls: unknown[] = []
+		const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => calls.push([level, fields])
+		const action = createProcedure('P', undefined, { errors: { table: { NOPE: { status: 418, title: 'Nope' } } } }).build()
+			.createAction('A')
+			.body(t.Object({ name: t.String() }))
+			.output(t.Object({ ok: t.Boolean() }))
+			.build(({ body }, onError) => { if (body.name === 'x') throw onError('NOPE'); return { ok: true } })
+
+		const g1 = new Elysia({ prefix: '/g1' }).use(problems({ log })).post('/a', action.handle, action.docs)
+		const g2 = new Elysia({ prefix: '/g2' }).use(problems({ log })).post('/a', action.handle, action.docs)
+		const app = new Elysia().use(problems({ log })).use(g1).use(g2)
+
+		const res = await app.handle(new Request('http://localhost/g2/a', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ name: 'x' }) }))
+		expect(res.status).toBe(418)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(await res.json()).toMatchObject({ status: 418, reason: 'NOPE' })
+		expect(calls.length).toBe(1)
+
+		const bad = await app.handle(new Request('http://localhost/g1/a', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({}) }))
+		expect(bad.status).toBe(422)
+		expect(calls.length).toBe(2)
+	})
+})

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -15,7 +15,7 @@ const Sentry = { captureException, captureMessage }
 const logs: { level: string; fields: Record<string, unknown> }[] = []
 const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => { logs.push({ level, fields }) }
 
-const base = createProcedure('Base', undefined, {
+const base = createProcedure('Base', {
 	errors: {
 		type: r => `/errors/${r}`,
 		table: {
@@ -375,7 +375,7 @@ describe('sub-apps', () => {
 	test('handles each error once when mounted on nested sub-apps', async () => {
 		const calls: unknown[] = []
 		const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => calls.push([level, fields])
-		const action = createProcedure('P', undefined, { errors: { table: { NOPE: { status: 418, title: 'Nope' } } } }).build()
+		const action = createProcedure('P', { errors: { table: { NOPE: { status: 418, title: 'Nope' } } } }).build()
 			.createAction('A')
 			.body(t.Object({ name: t.String() }))
 			.output(t.Object({ ok: t.Boolean() }))

--- a/tests/problems.test.ts
+++ b/tests/problems.test.ts
@@ -1,0 +1,288 @@
+// import dependencies
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+import { Elysia, t } from 'elysia'
+import { openapi } from '@elysiajs/openapi'
+import { createProcedure } from '@/procedure'
+import { problems } from '@/problems'
+import { ApiError } from '@/error'
+
+// mock the optional sentry dependency
+const captureException = mock(() => 'event-id-exception')
+const captureMessage = mock(() => 'event-id-message')
+mock.module('@sentry/bun', () => ({
+	captureException,
+	captureMessage,
+	startSpanManual: (_options: unknown, fn: (span?: unknown) => unknown) => fn(),
+}))
+
+const logs: { level: string; fields: Record<string, unknown> }[] = []
+const log = (level: 'warn' | 'error', fields: Record<string, unknown>) => { logs.push({ level, fields }) }
+
+const base = createProcedure('Base', undefined, {
+	errors: {
+		type: r => `/errors/${r}`,
+		table: {
+			NOT_FOUND: { status: 404, metadata: t.Object({ entity: t.String() }), title: (m: { entity: string }) => `${m.entity} not found` },
+			UPSTREAM_DOWN: { status: 502, title: 'Upstream down', detail: 'The upstream service did not respond.' },
+		}
+	}
+}).build()
+
+const notFound = base.createAction('Get Video').params(t.Object({ id: t.String() })).output(t.Object({ id: t.String() })).build(({ params }, onError) => {
+	throw onError('NOT_FOUND', { entity: 'Video' }, { detail: `Video ${params.id} is gone` })
+})
+const upstream = base.createAction('Upstream').build((_, onError) => {
+	throw onError('UPSTREAM_DOWN', undefined, { cause: new Error('socket hang up') })
+})
+const wrapped = base.createAction('Wrapped').build((_, onError) => {
+	throw onError.unexpected(new Error('db exploded'))
+})
+const create = base.createAction('Create Video').body(t.Object({
+	name: t.String({ minLength: 3 }),
+	password: t.String({ minLength: 8 }),
+	tags: t.Optional(t.Array(t.String()))
+})).build(({ body }) => body)
+const boom = base.createAction('Boom').build(() => { throw new Error('db exploded') })
+
+const build = (options?: Parameters<typeof problems>[0]) => new Elysia()
+	.use(problems({ log, ...options }))
+	.get('/videos/:id', notFound.handle, notFound.docs)
+	.get('/upstream', upstream.handle, upstream.docs)
+	.get('/wrapped', wrapped.handle, wrapped.docs)
+	.post('/videos', create.handle, create.docs)
+	.get('/boom', boom.handle, boom.docs)
+	.get('/redirect', ({ redirect }) => redirect('/videos/1', 302))
+	.get('/status', ({ status }) => status(302, 'moved'))
+
+const request = (app: { handle: (request: Request) => Promise<Response> }, path: string, init?: RequestInit) => app.handle(new Request(`http://localhost${path}`, init))
+
+beforeEach(() => {
+	logs.length = 0
+	captureException.mockClear()
+	captureMessage.mockClear()
+})
+
+describe('problems() plugin', () => {
+	test('serializes a 4xx ApiError without reporting', async () => {
+		const res = await request(build(), '/videos/abc')
+
+		expect(res.status).toBe(404)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(await res.json()).toEqual({
+			type: '/errors/NOT_FOUND',
+			title: 'Video not found',
+			status: 404,
+			detail: 'Video abc is gone',
+			instance: '/videos/abc',
+			reason: 'NOT_FOUND',
+			metadata: { entity: 'Video' },
+		})
+		expect(captureException).not.toHaveBeenCalled()
+		expect(captureMessage).not.toHaveBeenCalled()
+		expect(logs).toEqual([{ level: 'warn', fields: { status: 404, reason: 'NOT_FOUND', instance: '/videos/abc', method: 'GET' } }])
+	})
+
+	test('reports a 5xx ApiError and keeps author copy', async () => {
+		const res = await request(build(), '/upstream')
+		const body: any = await res.json()
+
+		expect(res.status).toBe(502)
+		expect(body).toEqual({
+			type: '/errors/UPSTREAM_DOWN',
+			title: 'Upstream down',
+			status: 502,
+			detail: 'The upstream service did not respond.',
+			instance: '/upstream',
+			reason: 'UPSTREAM_DOWN',
+			reference: 'event-id-exception',
+		})
+		expect(captureException).toHaveBeenCalledTimes(1)
+		expect((captureException.mock.calls[0] as unknown[])[0]).toBeInstanceOf(ApiError)
+		expect((captureException.mock.calls[0] as unknown[])[1]).toEqual({ tags: { reason: 'UPSTREAM_DOWN', status: 502 } })
+		expect(logs[0]?.level).toBe('error')
+		expect(logs[0]?.fields.message).toBe('socket hang up')
+	})
+
+	test('onError.unexpected hides the cause and reports it', async () => {
+		const res = await request(build(), '/wrapped')
+		const text = await res.text()
+
+		expect(res.status).toBe(500)
+		expect(text).not.toContain('db exploded')
+		expect(JSON.parse(text)).toMatchObject({ reason: 'INTERNAL', title: 'Something went wrong', reference: 'event-id-exception', type: '/errors/INTERNAL' })
+		expect(captureException).toHaveBeenCalledTimes(1)
+	})
+
+	test('maps validation errors to 422 with field errors', async () => {
+		const res = await request(build(), '/videos', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ name: '', password: 'hunter2hunter2', tags: ['a', 1] })
+		})
+		const body: any = await res.json()
+
+		expect(res.status).toBe(422)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(body).toMatchObject({ type: 'about:blank', title: 'Invalid input', status: 422, reason: 'INVALID_INPUT', instance: '/videos' })
+		expect(body.detail).toBe('2 fields are invalid: body.name, body.tags[1]')
+		expect(body.errors).toEqual([
+			{ in: 'body', pointer: '#/name', detail: expect.any(String), received: '""' },
+			{ in: 'body', pointer: '#/tags/1', detail: expect.any(String), received: '1' },
+		])
+		expect(captureException).not.toHaveBeenCalled()
+	})
+
+	test('elides sensitive received values and truncates long ones', async () => {
+		const res = await request(build({ receivedMaxLength: 10 }), '/videos', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ name: 'x'.repeat(50), password: 'short', tags: [1] })
+		})
+		const body: any = await res.json()
+
+		expect(res.status).toBe(422)
+		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/password').received).toBeUndefined()
+		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/tags/0').received).toBe('1')
+		expect(body.errors.find((e: { pointer: string }) => e.pointer === '#/name')).toBeUndefined()
+	})
+
+	test('omits received for missing properties and maps locations', async () => {
+		const app = new Elysia().use(problems({ log })).get('/q', () => 'ok', { query: t.Object({ page: t.Number() }) })
+		const res = await request(app, '/q')
+		const body: any = await res.json()
+
+		expect(res.status).toBe(422)
+		expect(body.errors.length).toBeGreaterThan(0)
+		for (const field of body.errors) {
+			expect(field).toEqual({ in: 'query', pointer: '#/page', detail: expect.any(String) })
+		}
+		expect(body.detail).toMatch(/^\d+ fields? (is|are) invalid: query\.page/)
+	})
+
+	test('treats response validation failures as server errors', async () => {
+		const app = new Elysia().use(problems({ log })).get('/r', () => ({ id: 1 }) as any, { response: t.Object({ id: t.String() }) })
+		const res = await request(app, '/r')
+		const body: any = await res.json()
+
+		expect(res.status).toBe(500)
+		expect(body.reason).toBe('INTERNAL')
+		expect(body.errors).toBeUndefined()
+		expect(captureException).toHaveBeenCalledTimes(1)
+	})
+
+	test('maps malformed JSON to 400', async () => {
+		const res = await request(build(), '/videos', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: '{not json'
+		})
+
+		expect(res.status).toBe(400)
+		expect(await res.json()).toMatchObject({ title: 'Malformed request', status: 400, reason: 'MALFORMED_REQUEST', instance: '/videos' })
+	})
+
+	test('maps unknown routes to 404', async () => {
+		const res = await request(build(), '/nope')
+
+		expect(res.status).toBe(404)
+		expect(await res.json()).toEqual({ type: 'about:blank', title: 'Not found', status: 404, instance: '/nope', reason: 'NOT_FOUND' })
+	})
+
+	test('uses the plugin error config for its own problems', async () => {
+		const res = await request(build({ errors: { type: r => `/plugin/${r}`, table: { NOT_FOUND: { status: 404, title: 'Nothing here' } } } }), '/nope')
+
+		expect(await res.json()).toMatchObject({ type: '/plugin/NOT_FOUND', title: 'Nothing here' })
+	})
+
+	test('maps plain errors to 500 without leaking the message', async () => {
+		const res = await request(build(), '/boom')
+		const text = await res.text()
+
+		expect(res.status).toBe(500)
+		expect(text).not.toContain('db exploded')
+		expect(JSON.parse(text)).toEqual({
+			type: 'about:blank',
+			title: 'Something went wrong',
+			status: 500,
+			detail: 'Please try again later. If the problem persists, contact support.',
+			instance: '/boom',
+			reason: 'INTERNAL',
+			reference: 'event-id-exception',
+		})
+		expect(captureException).toHaveBeenCalledTimes(1)
+		expect(logs[0]).toEqual({ level: 'error', fields: { status: 500, reason: 'INTERNAL', instance: '/boom', method: 'GET', reference: 'event-id-exception', message: 'db exploded' } })
+	})
+
+	test('leaves redirects and sub-400 statuses untouched', async () => {
+		const redirect = await request(build(), '/redirect')
+		expect(redirect.status).toBe(302)
+		expect(redirect.headers.get('content-type')).not.toBe('application/problem+json')
+
+		const status = await request(build(), '/status')
+		expect(status.status).toBe(302)
+		expect(await status.text()).toBe('moved')
+	})
+
+	test('captureClientErrors reports 4xx ApiErrors as messages', async () => {
+		await request(build({ captureClientErrors: 'warn' }), '/videos/abc')
+		expect(captureMessage).toHaveBeenCalledTimes(1)
+		expect(captureMessage.mock.calls[0] as unknown[]).toEqual(['Video not found', { level: 'warning', tags: { reason: 'NOT_FOUND', status: 404 } }])
+
+		await request(build({ captureClientErrors: 'all' }), '/videos/abc')
+		expect((captureMessage.mock.calls[1] as unknown[])[1]).toMatchObject({ level: 'info' })
+
+		await request(build({ captureClientErrors: 'off' }), '/videos/abc')
+		expect(captureMessage).toHaveBeenCalledTimes(2)
+	})
+
+	test('is idempotent when used on multiple instances', async () => {
+		const child = new Elysia().use(problems({ log })).get('/child', () => { throw new Error('x') })
+		const app = new Elysia().use(problems({ log })).use(child)
+
+		const res = await request(app, '/child')
+		expect(res.status).toBe(500)
+		expect(res.headers.get('content-type')).toBe('application/problem+json')
+		expect(logs).toHaveLength(1)
+	})
+})
+
+describe('openapi integration', () => {
+	test('documents error responses with a shared Problem schema', async () => {
+		const app = new Elysia().use(openapi()).use(build())
+		const res = await request(app, '/openapi/json')
+		const spec: any = await res.json()
+
+		expect(spec.components.schemas.Problem).toBeDefined()
+		expect(spec.components.schemas.Problem.properties.reason).toBeDefined()
+		expect(spec.components.schemas.Problem.properties.errors).toBeUndefined()
+		expect(spec.components.schemas.ValidationProblem.required).toContain('errors')
+		expect(spec.components.schemas.ValidationProblem.properties.errors.items.properties.in).toEqual({
+			type: 'string',
+			enum: ['body', 'path', 'query', 'header', 'cookie']
+		})
+
+		const responses = spec.paths['/videos/{id}'].get.responses
+		expect(Object.keys(responses).sort()).toEqual(['200', '400', '404', '422', '500', '502'])
+		expect(responses['404'].content['application/json'].schema).toEqual({ $ref: '#/components/schemas/Problem' })
+		expect(responses['422'].content['application/json'].schema).toEqual({ $ref: '#/components/schemas/ValidationProblem' })
+		expect(responses['200'].content['application/json'].schema.properties.id).toBeDefined()
+	})
+})
+
+describe('elysia built-in errors', () => {
+	test('maps invalid file types to 422', async () => {
+		const app = new Elysia()
+			.use(problems({ log }))
+			.post('/upload', () => 'ok', { body: t.Object({ file: t.File({ type: 'image/png' }) }) })
+
+		const form = new FormData()
+		form.append('file', new File(['hello'], 'a.txt', { type: 'text/plain' }))
+		const res = await request(app, '/upload', { method: 'POST', body: form })
+		const body: any = await res.json()
+
+		expect(res.status).toBe(422)
+		expect(body.reason).toBe('INVALID_INPUT')
+		expect(body.errors?.[0]).toMatchObject({ in: 'body', pointer: '#/file' })
+		expect(body.detail).toBe('1 field is invalid: body.file')
+	})
+})

--- a/tests/procedure.test.ts
+++ b/tests/procedure.test.ts
@@ -1,7 +1,7 @@
 // import dependencies
 import { describe, test, expect, mock } from 'bun:test'
 import { Type } from '@sinclair/typebox'
-import { createProcedure } from '@/procedure'
+import { createProcedure, Procedure } from '@/procedure'
 
 describe('Basic Procedure Creation', () => {
 	test('should create a procedure with name', () => {
@@ -185,6 +185,42 @@ describe('Middleware Execution', () => {
 		expect(mockHandler).toHaveBeenCalledTimes(2)
 		expect(resultOne).toEqual({ processed: true })
 		expect(resultTwo).toEqual({ processed: true })
+	})
+
+	test('should not confuse keys that join to the same string', async () => {
+		const mockHandler = mock(() => ({ processed: true }))
+
+		const procedure = createProcedure('Test Procedure')
+			.params(Type.Object({ keys: Type.Array(Type.String()) }))
+			.cache(({ params }) => params.keys)
+			.build(mockHandler)
+
+		const request = new Request('https://example.com')
+		await procedure.middlewares[0]?.execute({ ctx: { request }, params: { keys: ['a,b'] }, query: undefined, body: undefined })
+		await procedure.middlewares[0]?.execute({ ctx: { request }, params: { keys: ['a', 'b'] }, query: undefined, body: undefined })
+
+		expect(mockHandler).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('Procedure.is', () => {
+	test('recognizes procedures by brand rather than prototype', () => {
+		const procedure = createProcedure('Test Procedure').build()
+		const foreign = Object.assign(Object.create(null), procedure, { [Symbol.for('elysia-procedures.Procedure')]: true })
+
+		expect(Procedure.is(procedure)).toBe(true)
+		expect(Procedure.is(foreign)).toBe(true)
+		expect(Procedure.is({ middlewares: [] })).toBe(false)
+		expect(Procedure.is(null)).toBe(false)
+	})
+
+	test('createProcedure keeps the middlewares of a base from another copy of the package', () => {
+		const base = createProcedure('Base').build(() => ({ authenticated: true }))
+		const foreign = Object.assign(Object.create(null), base, { [Symbol.for('elysia-procedures.Procedure')]: true })
+
+		const child = createProcedure('Child', foreign as typeof base).build()
+		expect(child.middlewares).toHaveLength(1)
+		expect(child.middlewares[0]).toBe(base.middlewares[0])
 	})
 })
 

--- a/tests/procedure.test.ts
+++ b/tests/procedure.test.ts
@@ -98,7 +98,7 @@ describe('Middleware Execution', () => {
 		const result = await procedure.middlewares[0]?.execute(input)
 
 		expect(mockHandler).toHaveBeenCalledTimes(1)
-		expect(mockHandler).toHaveBeenCalledWith(input)
+		expect(mockHandler).toHaveBeenCalledWith(input, expect.any(Function))
 		expect(result).toEqual({ processed: true })
 	})
 
@@ -121,7 +121,7 @@ describe('Middleware Execution', () => {
 		const resultTwo = await procedure.middlewares[0]?.execute(input)
 
 		expect(mockHandler).toHaveBeenCalledTimes(1)
-		expect(mockHandler).toHaveBeenCalledWith(input)
+		expect(mockHandler).toHaveBeenCalledWith(input, expect.any(Function))
 		expect(resultOne).toEqual({ processed: true })
 		expect(resultTwo).toEqual({ processed: true })
 	})
@@ -272,8 +272,8 @@ describe('Chained Procedures', () => {
 		})
 
 		expect(baseHandler).toHaveBeenCalledTimes(1)
-		expect(baseHandler).toHaveBeenCalledWith(input)
+		expect(baseHandler).toHaveBeenCalledWith(input, expect.any(Function))
 		expect(derivedHandler).toHaveBeenCalledTimes(1)
-		expect(derivedHandler).toHaveBeenCalledWith(secondInput)
+		expect(derivedHandler).toHaveBeenCalledWith(secondInput, expect.any(Function))
 	})
 })

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -1,0 +1,185 @@
+// import dependencies
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test'
+import { Elysia, t } from 'elysia'
+import { trace as otel, context, SpanStatusCode, ROOT_CONTEXT } from '@opentelemetry/api'
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { createProcedure } from '@/procedure'
+import { procedures } from '@/plugin'
+import { configureTracing } from '@/trace'
+
+// import types
+import type { Tracer, Span, SpanOptions, Context, Attributes, ContextManager } from '@opentelemetry/api'
+
+// propagate the active span the way an otel sdk would
+const storage = new AsyncLocalStorage<Context>()
+const manager: ContextManager = {
+	active: () => storage.getStore() ?? ROOT_CONTEXT,
+	with: (ctx, fn, thisArg, ...args) => storage.run(ctx, () => fn.call(thisArg, ...args)),
+	bind: (_ctx, target) => target,
+	enable() { return this },
+	disable() { return this },
+}
+context.setGlobalContextManager(manager)
+
+type Recorded = {
+	name: string
+	parent?: string
+	attributes: Attributes
+	status?: { code: SpanStatusCode, message?: string }
+	exceptions: unknown[]
+	ended: boolean
+}
+
+/** An in-memory tracer that records every span and nests them through the otel context */
+const recorder = () => {
+	const spans: Recorded[] = []
+
+	const tracer: Tracer = {
+		startSpan: () => { throw new Error('not used') },
+		startActiveSpan: (...args: unknown[]) => {
+			const name = args[0] as string
+			const fn = args[args.length - 1] as (span: Span) => unknown
+			const options = (args.length > 2 ? args[1] : {}) as SpanOptions
+			const parent = args.length > 3 ? args[2] as Context : context.active()
+			const recorded: Recorded = { name, parent: (otel.getSpan(parent) as any)?.recorded?.name, attributes: { ...options.attributes }, exceptions: [], ended: false }
+			spans.push(recorded)
+
+			const span = {
+				recorded,
+				spanContext: () => ({ traceId: '1', spanId: String(spans.length), traceFlags: 1 }),
+				setAttribute(key: string, value: unknown) { recorded.attributes[key] = value as never; return span },
+				setAttributes(attributes: Attributes) { Object.assign(recorded.attributes, attributes); return span },
+				setStatus(status: { code: SpanStatusCode, message?: string }) { recorded.status = status; return span },
+				recordException(error: unknown) { recorded.exceptions.push(error) },
+				end() { recorded.ended = true },
+				isRecording: () => true,
+				updateName: () => span,
+				addEvent: () => span,
+				addLink: () => span,
+				addLinks: () => span,
+			} as unknown as Span
+
+			return context.with(otel.setSpan(parent, span), () => fn(span))
+		}
+	}
+
+	return { tracer, spans }
+}
+
+const base = createProcedure('Base', undefined, {
+	errors: { table: { NOT_FOUND: { status: 404 }, UPSTREAM_DOWN: { status: 502 } } }
+}).build()
+
+const withAuth = createProcedure('Auth', base, { tracing: { name: 'authenticate', attributes: { 'auth.kind': 'bearer' } } }).build(() => ({ user: 'me' }))
+
+const ok = withAuth.createAction('Get Video', { tracing: { attributes: { 'video.source': 'db' } } })
+	.params(t.Object({ id: t.String() })).output(t.Object({ id: t.String() }))
+	.build(({ params }) => ({ id: params.id }))
+const notFound = withAuth.createAction('Missing').build((_, onError) => { throw onError('NOT_FOUND') })
+const upstream = withAuth.createAction('Upstream').build((_, onError) => { throw onError('UPSTREAM_DOWN') })
+const boom = withAuth.createAction('Boom').build(() => { throw new Error('db exploded') })
+
+const build = (tracing?: Parameters<typeof procedures>[0] extends infer O ? O extends { observability?: infer Ob } ? Ob extends { tracing?: infer T } ? T : never : never : never) => new Elysia()
+	.use(procedures({ observability: { logging: () => {}, tracing } }))
+	.get('/videos/:id', ok.handle, ok.docs)
+	.get('/missing', notFound.handle, notFound.docs)
+	.get('/upstream', upstream.handle, upstream.docs)
+	.get('/boom', boom.handle, boom.docs)
+
+const request = (app: { handle: (request: Request) => Promise<Response> }, path: string) => app.handle(new Request(`http://localhost${path}`))
+const ctx = () => ({ request: new Request('http://localhost/') }) as any
+
+beforeEach(() => configureTracing(false))
+afterAll(() => {
+	configureTracing(false)
+	context.disable()
+})
+
+describe('tracing', () => {
+	test('is off unless configured', async () => {
+		const { tracer, spans } = recorder()
+		otel.setGlobalTracerProvider({ getTracer: () => tracer })
+
+		await request(build(), '/videos/1')
+		expect(spans).toHaveLength(0)
+
+		await ok.run(ctx(), { params: { id: '1' }, query: undefined, body: undefined })
+		expect(spans).toHaveLength(0)
+
+		otel.disable()
+	})
+
+	test('tracing: true uses the global tracer provider', async () => {
+		const { tracer, spans } = recorder()
+		otel.setGlobalTracerProvider({ getTracer: () => tracer })
+
+		const res = await request(build(true), '/videos/1')
+		expect(res.status).toBe(200)
+		expect(spans.map(s => s.name)).toEqual(['Get Video', 'authenticate', 'Get Video'])
+
+		otel.disable()
+	})
+
+	test('nests middleware and handler spans under the action span', async () => {
+		const { tracer, spans } = recorder()
+		await request(build({ tracer, attributes: { 'service.layer': 'api' } }), '/videos/1')
+
+		const [action, middleware, handler] = spans
+		expect(action).toMatchObject({ name: 'Get Video', parent: undefined, ended: true, attributes: { 'sentry.op': 'procedure.action', 'procedure.type': 'action', 'procedure.name': 'Get Video', 'video.source': 'db', 'service.layer': 'api' } })
+		expect(middleware).toMatchObject({ name: 'authenticate', parent: 'Get Video', ended: true, attributes: { 'sentry.op': 'procedure.middleware', 'procedure.type': 'middleware', 'procedure.name': 'Auth', 'auth.kind': 'bearer', 'procedure.cache': 'unavailable' } })
+		expect(handler).toMatchObject({ name: 'Get Video', parent: 'Get Video', ended: true, attributes: { 'sentry.op': 'procedure.handler', 'procedure.type': 'handler', 'video.source': 'db' } })
+		expect(spans.every(s => s.status === undefined)).toBe(true)
+	})
+
+	test('run() adds input and output validation spans', async () => {
+		const { tracer, spans } = recorder()
+		configureTracing({ tracer })
+
+		await ok.run(ctx(), { params: { id: '1' }, query: undefined, body: undefined })
+		expect(spans.map(s => `${s.attributes['procedure.type']}:${s.parent ?? '-'}`)).toEqual(['action:-', 'input:Get Video', 'middleware:Get Video', 'handler:Get Video', 'output:Get Video'])
+		expect(spans.every(s => s.ended)).toBe(true)
+	})
+
+	test('span types can be disabled', async () => {
+		const { tracer, spans } = recorder()
+		configureTracing({ tracer, spans: { input: false, output: false, middleware: false } })
+
+		await ok.run(ctx(), { params: { id: '1' }, query: undefined, body: undefined })
+		expect(spans.map(s => s.attributes['procedure.type'])).toEqual(['action', 'handler'])
+	})
+
+	test('records unexpected and 5xx failures as span errors and still ends the spans', async () => {
+		const { tracer, spans } = recorder()
+		const app = build({ tracer })
+
+		await request(app, '/boom')
+		const [action, , handler] = spans
+		expect(handler).toMatchObject({ ended: true, status: { code: SpanStatusCode.ERROR, message: 'db exploded' } })
+		expect(handler?.exceptions[0]).toBeInstanceOf(Error)
+		expect(action).toMatchObject({ ended: true, status: { code: SpanStatusCode.ERROR } })
+
+		spans.length = 0
+		await request(app, '/upstream')
+		expect(spans[2]).toMatchObject({ ended: true, status: { code: SpanStatusCode.ERROR }, attributes: { 'procedure.type': 'handler' } })
+	})
+
+	test('marks 4xx ApiErrors on the span without an error status', async () => {
+		const { tracer, spans } = recorder()
+		await request(build({ tracer }), '/missing')
+
+		const handler = spans[2]
+		expect(handler).toMatchObject({ ended: true, attributes: { 'procedure.error.reason': 'NOT_FOUND', 'procedure.error.status': 404 }, exceptions: [] })
+		expect(handler?.status).toBeUndefined()
+		expect(spans[0]?.status).toBeUndefined()
+	})
+
+	test('input validation failures in run() end the spans', async () => {
+		const { tracer, spans } = recorder()
+		configureTracing({ tracer })
+
+		await expect(ok.run(ctx(), { params: {} as any, query: undefined, body: undefined })).rejects.toThrow()
+		expect(spans.map(s => s.attributes['procedure.type'])).toEqual(['action', 'input'])
+		expect(spans.every(s => s.ended)).toBe(true)
+		expect(spans[1]?.status?.code).toBe(SpanStatusCode.ERROR)
+	})
+})

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -66,7 +66,7 @@ const recorder = () => {
 	return { tracer, spans }
 }
 
-const base = createProcedure('Base', undefined, {
+const base = createProcedure('Base', {
 	errors: { table: { NOT_FOUND: { status: 404 }, UPSTREAM_DOWN: { status: 502 } } }
 }).build()
 

--- a/tests/types.tst.ts
+++ b/tests/types.tst.ts
@@ -2,11 +2,13 @@
 import { describe, test, expect } from 'tstyche'
 import { Type } from '@sinclair/typebox'
 import { createProcedure } from '../src/procedure'
+import { defineError } from '../src/error'
 
 // import types
 import type { Procedure } from '../src/procedure'
 import type { Action } from '../src/action'
-import type { TObject, TString, TNumber } from '@sinclair/typebox'
+import type { ApiError } from '../src/error'
+import type { TObject, TString, TNumber, TBoolean } from '@sinclair/typebox'
 import type { Context } from '../src/utils'
 import type { Cookie } from 'elysia'
 
@@ -410,5 +412,87 @@ describe('Action Inference', () => {
 			.output(Type.String())
 
 		expect(builder.build(() => { return { processed: true } })).type.toRaiseError(`Type '{ processed: boolean; }' is not assignable to type 'Promisable<string>'.`)
+	})
+})
+describe('Error Inference', () => {
+	const base = createProcedure('Base', undefined, {
+		errors: {
+			type: r => `/errors/${r}`,
+			table: {
+				NOT_FOUND: { status: 404, metadata: Type.Object({ entity: Type.String() }), title: (m: { entity: string }) => `${m.entity} not found` },
+				FORBIDDEN: { status: 403 },
+			}
+		}
+	}).build()
+
+	test('should type onError from the table', () => {
+		base.createAction('Test').build((_, onError) => {
+			expect(onError('NOT_FOUND', { entity: 'Video' })).type.toBe<ApiError<'NOT_FOUND', { entity: string }>>()
+			expect(onError('FORBIDDEN')).type.toBe<ApiError<'FORBIDDEN', undefined>>()
+			expect(onError.unexpected(new Error('x'))).type.toBe<ApiError<string, undefined>>()
+			expect(onError('INTERNAL')).type.toBe<ApiError<'INTERNAL', undefined>>()
+			expect(onError('NOT_FOUND', { entity: 'Video' })).type.toBe<ApiError<'NOT_FOUND', { entity: string }>>()
+		})
+	})
+
+	test('should reject unknown reasons and missing metadata', () => {
+		base.createAction('Test').build((_, onError) => {
+			expect(onError('NOPE')).type.toRaiseError()
+			expect(onError('NOT_FOUND')).type.toRaiseError()
+			expect(onError('NOT_FOUND', { entity: 1 })).type.toRaiseError()
+			expect(onError('FORBIDDEN', { entity: 'x' })).type.toRaiseError()
+		})
+	})
+
+	test('should merge child tables over parent tables', () => {
+		const child = createProcedure('Child', base, {
+			errors: { table: { FORBIDDEN: { status: 403, metadata: Type.Object({ role: Type.String() }) }, CONFLICT: { status: 409 } } }
+		}).build()
+
+		child.createAction('Test', { errors: { table: { GONE: { status: 410 } } } }).build((_, onError) => {
+			expect(onError('FORBIDDEN', { role: 'admin' })).type.toBe<ApiError<'FORBIDDEN', { role: string }>>()
+			expect(onError('FORBIDDEN')).type.toRaiseError()
+			expect(onError('NOT_FOUND', { entity: 'Video' })).type.toBe<ApiError<'NOT_FOUND', { entity: string }>>()
+			expect(onError('CONFLICT')).type.toBe<ApiError<'CONFLICT', undefined>>()
+			expect(onError('GONE')).type.toBe<ApiError<'GONE', undefined>>()
+		})
+	})
+
+	test('should pass onError to middleware handlers', () => {
+		createProcedure('Child', base).build((_, onError) => {
+			expect(onError('FORBIDDEN')).type.toBe<ApiError<'FORBIDDEN', undefined>>()
+		})
+	})
+
+	test('should type entry copy functions through defineError', () => {
+		const procedure = createProcedure('Defined', undefined, {
+			errors: { table: {
+				GONE: defineError({ status: 410, metadata: Type.Object({ id: Type.String() }), title: m => m.id }),
+				TEAPOT: defineError({ status: 418, title: () => 'short and stout' }),
+			} }
+		}).build()
+
+		procedure.createAction('Test').build((_, onError) => {
+			expect(onError('GONE', { id: 'x' })).type.toBe<ApiError<'GONE', { id: string }>>()
+			expect(onError('TEAPOT')).type.toBe<ApiError<'TEAPOT', undefined>>()
+			expect(onError('GONE')).type.toRaiseError()
+		})
+
+		const action = procedure.createAction('Test').build(() => ({ ok: true }))
+		expect(action.docs.response[410]).type.toBe<'Problem'>()
+		expect(action.docs.response[418]).type.toBe<'Problem'>()
+	})
+
+	test('should keep one-argument handlers compiling', () => {
+		expect(base.createAction('Test').build(() => ({ ok: true }))).type.not.toRaiseError()
+	})
+
+	test('should document error responses in docs', () => {
+		const action = base.createAction('Test').build(() => ({ ok: true }))
+		expect(action.docs.response).type.toBe<{ 403: 'Problem'; 404: 'Problem'; 422: 'ValidationProblem'; 500: 'Problem'; 400: 'Problem' }>()
+
+		const typed = base.createAction('Test').output(Type.Object({ ok: Type.Boolean() })).build(() => ({ ok: true }))
+		expect(typed.docs.response[200]).type.toBe<TObject<{ ok: TBoolean }>>()
+		expect(typed.docs.response[404]).type.toBe<'Problem'>()
 	})
 })

--- a/tests/types.tst.ts
+++ b/tests/types.tst.ts
@@ -7,7 +7,7 @@ import { defineError } from '../src/error'
 // import types
 import type { Procedure } from '../src/procedure'
 import type { Action } from '../src/action'
-import type { ApiError } from '../src/error'
+import type { ApiError, Problem, ValidationProblem } from '../src/error'
 import type { TObject, TString, TNumber, TBoolean } from '@sinclair/typebox'
 import type { Context } from '../src/utils'
 import type { Cookie } from 'elysia'
@@ -479,8 +479,8 @@ describe('Error Inference', () => {
 		})
 
 		const action = procedure.createAction('Test').build(() => ({ ok: true }))
-		expect(action.docs.response[410]).type.toBe<'Problem'>()
-		expect(action.docs.response[418]).type.toBe<'Problem'>()
+		expect(action.docs.response[410]).type.toBe<typeof Problem>()
+		expect(action.docs.response[418]).type.toBe<typeof Problem>()
 	})
 
 	test('should keep one-argument handlers compiling', () => {
@@ -489,10 +489,10 @@ describe('Error Inference', () => {
 
 	test('should document error responses in docs', () => {
 		const action = base.createAction('Test').build(() => ({ ok: true }))
-		expect(action.docs.response).type.toBe<{ 403: 'Problem'; 404: 'Problem'; 422: 'ValidationProblem'; 500: 'Problem'; 400: 'Problem' }>()
+		expect(action.docs.response).type.toBe<{ 403: typeof Problem; 404: typeof Problem; 422: typeof ValidationProblem; 500: typeof Problem; 400: typeof Problem }>()
 
 		const typed = base.createAction('Test').output(Type.Object({ ok: Type.Boolean() })).build(() => ({ ok: true }))
 		expect(typed.docs.response[200]).type.toBe<TObject<{ ok: TBoolean }>>()
-		expect(typed.docs.response[404]).type.toBe<'Problem'>()
+		expect(typed.docs.response[404]).type.toBe<typeof Problem>()
 	})
 })

--- a/tests/types.tst.ts
+++ b/tests/types.tst.ts
@@ -415,7 +415,7 @@ describe('Action Inference', () => {
 	})
 })
 describe('Error Inference', () => {
-	const base = createProcedure('Base', undefined, {
+	const base = createProcedure('Base', {
 		errors: {
 			type: r => `/errors/${r}`,
 			table: {
@@ -465,7 +465,7 @@ describe('Error Inference', () => {
 	})
 
 	test('should type entry copy functions through defineError', () => {
-		const procedure = createProcedure('Defined', undefined, {
+		const procedure = createProcedure('Defined', {
 			errors: { table: {
 				GONE: defineError({ status: 410, metadata: Type.Object({ id: Type.String() }), title: m => m.id }),
 				TEAPOT: defineError({ status: 418, title: () => 'short and stout' }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     }
   },
   "exclude": [
-    "**/*.tst.ts"
+    "**/*.tst.ts",
+    "bench"
   ]
 }


### PR DESCRIPTION
Before this branch an error thrown from a handler became whatever Elysia felt like sending. A typed `ApiError` turned into plain text, an unexpected `Error` went out with its raw message, and validation failures used Elysia's own JSON shape while the OpenAPI spec pointed at models nobody registered. This PR replaces that with one wire contract: every failure that escapes a route is an `application/problem+json` body, and the error table you declare on a procedure is what the handler can throw and what `action.docs` documents.

It also makes tracing vendor-neutral and rewrites the type-level schema merging, which is why this is 0.4.0 rather than a patch. I used the minor bump to land the bench harness and the dependency changes in one go rather than spreading them over three PRs.

## Errors

You declare a table in `createProcedure(name, config)` or `createProcedure(name, base, config)`, and in `createAction` details. Tables merge by key down the chain, the child wins, and the `type` function is inherited. Every handler and middleware gets `onError` as its second argument, typed from the effective table. An unknown reason does not compile. Metadata is required exactly when the entry declares a schema, and is validated at throw time. A mismatch throws a plain `TypeError` because that is a handler bug, not an API error.

```ts
throw onError("NOT_FOUND", { entity: "Video", id: params.id });
throw onError.unexpected(cause, { reason: "UPSTREAM_DOWN" });
```

`INTERNAL`, `INVALID_INPUT`, `MALFORMED_REQUEST` and `NOT_FOUND` are always present. You can override them by key but not remove them. `defineError(...)` exists only so the `title`/`detail` functions infer their metadata parameter from the schema; inside a plain object literal TypeScript cannot do that.

The `procedures()` plugin is the Elysia side. Mount it once on the root app, before sub-apps. It registers the `Problem` and `ValidationProblem` models and a global `onError` that maps everything per the table in the README. Unexpected errors collapse to `INTERNAL` with default copy; the raw message only ever reaches the logger, and only for 5xx. Reporting is off by default. `sentryReporter(Sentry)` captures 5xx as exceptions and, if you ask, 4xx as messages. Whatever a reporter returns becomes the problem's `reference`.

The plugin is built from exported pieces (`procedureModels`, `resolveProblem`, `problemResponse`, `sentryReporter`, `configureTracing`), so an app with its own `onError` can keep the contract and skip the rest.

## Tracing

The old tracing leaned on `@elysiajs/opentelemetry` and `@sentry/bun` as peers. Now spans are created through `@opentelemetry/api` only, so they nest under whichever provider is registered globally. `@opentelemetry/api` is a real dependency now and the two peers are gone. A 4xx `ApiError` does not fail a span. Everything else does.

## Type-checking

Checking a schema against `TObject` made TypeScript evaluate the schema's `static` type on every generic constraint. On a large consumer that was enough to OOM `tsc`. `ObjectSchema` is a structural stand-in that only compares `type` and `properties`, roughly forty times cheaper in the bench, and `SafeTObject`/`MergedObject` were rewritten around it. `bench/` generates a consumer with N procedures and N actions and measures `tsc` with `--extendedDiagnostics`. It is gitignored output plus a small generator, and excluded from lint.

## Hardening from review

Three things came out of a security pass over the full implementation. None were exploitable as shipped, but one failed in the wrong direction.

`createProcedure(name, base)` used `instanceof Procedure` to tell a base from a config object. The package ships CJS and ESM. If the base came from the other copy, the check was false and the base was silently treated as config, dropping its middlewares. An auth middleware, say. `Procedure` and `ApiError` now carry a `Symbol.for` brand with a static `is()` guard, and every `instanceof` on them is gone. There is a test that feeds a foreign-prototype base through and checks the middleware survives.

`received` in validation problems only redacted by pointer segment. A union failing at `/credentials` stringified the whole object, nested `password` included, back to the sender. The serializer now walks the value and replaces any property matching `/password|secret|token|key/i` with `"[redacted]"`.

Cache keys were `keys.join(',')`, so `['a,b']` and `['a','b']` shared an entry. Now `JSON.stringify`.

## Style

Two new ESLint rules. `@stylistic/member-delimiter-style` auto-fixes the semicolons that were creeping into type members, and `no-mixed-spaces-and-tabs` catches space-indented continuation lines. `error.ts` had been written Prettier-style and is now wrapped like the rest of the repo.

## Checks

eslint, `tsc --noEmit`, 87 bun tests and 27 tstyche type tests all pass.